### PR TITLE
feat: add POST /ingest with auth, validation, dedup, and SQLite inbox

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,208 @@
+/**
+ * SQLite database for Cortex.
+ *
+ * Manages inbox/outbox queues, turns, extraction cursors, and scheduler jobs.
+ * Tables are created incrementally as each slice adds its schema.
+ *
+ * Database location: ~/.local/share/cortex/cortex.db
+ * Tests can override via initDatabase({ path: ":memory:", force: true }).
+ */
+
+import { Database } from "bun:sqlite";
+import { mkdirSync } from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
+
+// --- Connection ---
+
+let db: Database | null = null;
+
+const DEFAULT_DB_PATH = join(
+  homedir(),
+  ".local",
+  "share",
+  "cortex",
+  "cortex.db",
+);
+
+export function initDatabase(options?: {
+  path?: string;
+  force?: boolean;
+}): Database {
+  if (db && !options?.force) return db;
+  if (db) {
+    db.close();
+    db = null;
+  }
+
+  const dbPath = options?.path ?? DEFAULT_DB_PATH;
+
+  if (dbPath !== ":memory:") {
+    mkdirSync(dirname(dbPath), { recursive: true });
+  }
+
+  db = new Database(dbPath);
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+
+  createSchema(db);
+  return db;
+}
+
+export function getDatabase(): Database {
+  if (!db) {
+    throw new Error("Database not initialized. Call initDatabase() first.");
+  }
+  return db;
+}
+
+export function closeDatabase(): void {
+  if (db) {
+    db.close();
+    db = null;
+  }
+}
+
+// --- Schema ---
+
+function createSchema(database: Database): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS inbox_messages (
+      id TEXT PRIMARY KEY,
+      source TEXT NOT NULL,
+      external_message_id TEXT NOT NULL,
+      topic_key TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      text TEXT NOT NULL,
+      occurred_at INTEGER NOT NULL,
+      idempotency_key TEXT NOT NULL,
+      metadata_json TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      attempts INTEGER NOT NULL DEFAULT 0,
+      error TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      -- Dedup is on (source, external_message_id), NOT idempotency_key.
+      -- idempotency_key is stored for connector-layer tracing/debugging.
+      UNIQUE(source, external_message_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_inbox_status_created
+      ON inbox_messages(status, created_at);
+    CREATE INDEX IF NOT EXISTS idx_inbox_topic_status
+      ON inbox_messages(topic_key, status);
+  `);
+}
+
+// --- Inbox operations ---
+
+export interface InboxInsertInput {
+  source: string;
+  externalMessageId: string;
+  topicKey: string;
+  userId: string;
+  text: string;
+  occurredAt: number;
+  idempotencyKey: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface InboxMessage {
+  id: string;
+  source: string;
+  external_message_id: string;
+  topic_key: string;
+  user_id: string;
+  text: string;
+  occurred_at: number;
+  idempotency_key: string;
+  metadata_json: string | null;
+  status: string;
+  attempts: number;
+  error: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+/**
+ * Check if an inbox message already exists for this (source, externalMessageId).
+ * Returns the existing message ID if found, null otherwise.
+ */
+export function findInboxDuplicate(
+  source: string,
+  externalMessageId: string,
+): string | null {
+  const database = getDatabase();
+  const stmt = database.prepare(
+    "SELECT id FROM inbox_messages WHERE source = $source AND external_message_id = $externalMessageId",
+  );
+  const row = stmt.get({
+    $source: source,
+    $externalMessageId: externalMessageId,
+  }) as { id: string } | null;
+  return row?.id ?? null;
+}
+
+export interface EnqueueResult {
+  eventId: string;
+  duplicate: boolean;
+}
+
+/**
+ * Insert a new inbox message. If a UNIQUE constraint violation occurs
+ * (concurrent duplicate), falls back to returning the existing row's ID.
+ */
+export function enqueueInboxMessage(input: InboxInsertInput): EnqueueResult {
+  const database = getDatabase();
+  const id = `evt_${crypto.randomUUID()}`;
+  const now = Date.now();
+
+  const stmt = database.prepare(`
+    INSERT INTO inbox_messages (
+      id, source, external_message_id, topic_key, user_id, text,
+      occurred_at, idempotency_key, metadata_json, status, attempts,
+      created_at, updated_at
+    ) VALUES (
+      $id, $source, $externalMessageId, $topicKey, $userId, $text,
+      $occurredAt, $idempotencyKey, $metadataJson, 'pending', 0,
+      $now, $now
+    )
+  `);
+
+  try {
+    stmt.run({
+      $id: id,
+      $source: input.source,
+      $externalMessageId: input.externalMessageId,
+      $topicKey: input.topicKey,
+      $userId: input.userId,
+      $text: input.text,
+      $occurredAt: input.occurredAt,
+      $idempotencyKey: input.idempotencyKey,
+      $metadataJson: input.metadata ? JSON.stringify(input.metadata) : null,
+      $now: now,
+    });
+    return { eventId: id, duplicate: false };
+  } catch (err) {
+    // UNIQUE constraint violation — concurrent duplicate slipped past the check
+    if (err instanceof Error && err.message.includes("UNIQUE constraint")) {
+      const existingId = findInboxDuplicate(
+        input.source,
+        input.externalMessageId,
+      );
+      if (existingId) {
+        return { eventId: existingId, duplicate: true };
+      }
+    }
+    throw err;
+  }
+}
+
+/**
+ * Get an inbox message by ID.
+ */
+export function getInboxMessage(id: string): InboxMessage | null {
+  const database = getDatabase();
+  const stmt = database.prepare("SELECT * FROM inbox_messages WHERE id = $id");
+  return (stmt.get({ $id: id }) as InboxMessage) ?? null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,13 @@
  */
 
 import { loadConfig } from "./config";
+import { initDatabase } from "./db";
 import { createServer } from "./server";
 import { VERSION } from "./version";
 
 console.log(`cortex v${VERSION}`);
 
 const config = loadConfig();
+initDatabase();
 const server = createServer(config);
 server.start();

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,42 +1,173 @@
 /**
  * HTTP server for Cortex.
  *
- * Currently serves:
- *   GET /health — health check for Wilson integration
- *
- * Future slices add:
- *   POST /ingest — channel-agnostic event ingress
- *   POST /outbox/poll — connector delivery claim
- *   POST /outbox/ack — connector delivery acknowledgement
+ * Routes:
+ *   GET  /health      — health check for Wilson integration
+ *   POST /ingest      — channel-agnostic event ingress
+ *   POST /outbox/poll — connector delivery claim (future)
+ *   POST /outbox/ack  — connector delivery acknowledgement (future)
  */
 
+import { timingSafeEqual } from "crypto";
 import type { CortexConfig } from "./config";
+import { enqueueInboxMessage, findInboxDuplicate } from "./db";
 import { VERSION } from "./version";
 
 const startedAt = Date.now();
 
-function healthResponse(): Response {
-  const uptime = Math.floor((Date.now() - startedAt) / 1000);
-  return Response.json({
-    status: "healthy",
-    version: VERSION,
-    uptime,
-  });
+// --- Helpers ---
+
+function jsonResponse(
+  body: unknown,
+  status: number,
+  headers?: Record<string, string>,
+): Response {
+  return Response.json(body, { status, headers });
 }
 
-function notFound(): Response {
-  return Response.json({ error: "not_found" }, { status: 404 });
-}
-
-function handleRequest(req: Request): Response {
-  const url = new URL(req.url);
-
-  if (req.method === "GET" && url.pathname === "/health") {
-    return healthResponse();
+function requireAuth(req: Request, config: CortexConfig): Response | null {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return jsonResponse({ error: "unauthorized" }, 401);
   }
 
-  return notFound();
+  const token = authHeader.slice("Bearer ".length);
+  const expected = config.ingestApiKey;
+
+  // Constant-time comparison to prevent timing attacks.
+  // Buffer lengths may differ; check length first (leaks length, not content).
+  const a = Buffer.from(token);
+  const b = Buffer.from(expected);
+  if (a.byteLength !== b.byteLength || !timingSafeEqual(a, b)) {
+    return jsonResponse({ error: "unauthorized" }, 401);
+  }
+
+  return null;
 }
+
+// --- Route handlers ---
+
+function handleHealth(): Response {
+  const uptime = Math.floor((Date.now() - startedAt) / 1000);
+  return jsonResponse({ status: "healthy", version: VERSION, uptime }, 200);
+}
+
+interface IngestRequestBody {
+  source?: string;
+  externalMessageId?: string;
+  idempotencyKey?: string;
+  topicKey?: string;
+  userId?: string;
+  text?: string;
+  occurredAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+function validateIngestBody(body: IngestRequestBody): string[] {
+  const details: string[] = [];
+  const requiredStringFields: Array<{
+    key: keyof IngestRequestBody;
+    label: string;
+  }> = [
+    { key: "source", label: "source" },
+    { key: "externalMessageId", label: "externalMessageId" },
+    { key: "idempotencyKey", label: "idempotencyKey" },
+    { key: "topicKey", label: "topicKey" },
+    { key: "userId", label: "userId" },
+    { key: "text", label: "text" },
+    { key: "occurredAt", label: "occurredAt" },
+  ];
+
+  for (const field of requiredStringFields) {
+    const val = body[field.key];
+    if (val === undefined || val === null) {
+      details.push(`${field.label} is required`);
+    } else if (typeof val !== "string" || val.length === 0) {
+      details.push(`${field.label} must be a non-empty string`);
+    }
+  }
+
+  if (
+    body.occurredAt &&
+    typeof body.occurredAt === "string" &&
+    body.occurredAt.length > 0
+  ) {
+    const ts = new Date(body.occurredAt).getTime();
+    if (Number.isNaN(ts)) {
+      details.push("occurredAt must be a valid ISO 8601 date string");
+    }
+  }
+
+  return details;
+}
+
+async function handleIngest(
+  req: Request,
+  config: CortexConfig,
+): Promise<Response> {
+  const authError = requireAuth(req, config);
+  if (authError) return authError;
+
+  let body: IngestRequestBody;
+  try {
+    body = (await req.json()) as IngestRequestBody;
+  } catch {
+    return jsonResponse(
+      {
+        error: "invalid_request",
+        details: ["Request body must be valid JSON"],
+      },
+      400,
+    );
+  }
+
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return jsonResponse(
+      {
+        error: "invalid_request",
+        details: ["Request body must be a JSON object"],
+      },
+      400,
+    );
+  }
+
+  const details = validateIngestBody(body);
+  if (details.length > 0) {
+    return jsonResponse({ error: "invalid_request", details }, 400);
+  }
+
+  // Dedup check (optimistic — avoids insert overhead in common case)
+  const existingId = findInboxDuplicate(body.source!, body.externalMessageId!);
+  if (existingId) {
+    return jsonResponse(
+      { eventId: existingId, status: "duplicate_ignored" },
+      200,
+    );
+  }
+
+  // Enqueue (catches UNIQUE constraint race if concurrent duplicate slips past)
+  const result = enqueueInboxMessage({
+    source: body.source!,
+    externalMessageId: body.externalMessageId!,
+    topicKey: body.topicKey!,
+    userId: body.userId!,
+    text: body.text!,
+    occurredAt: new Date(body.occurredAt!).getTime(),
+    idempotencyKey: body.idempotencyKey!,
+    metadata: body.metadata,
+  });
+
+  if (result.duplicate) {
+    return jsonResponse(
+      { eventId: result.eventId, status: "duplicate_ignored" },
+      200,
+    );
+  }
+
+  return jsonResponse({ eventId: result.eventId, status: "queued" }, 202);
+}
+
+// --- Server ---
 
 export interface CortexServer {
   start(): ReturnType<typeof Bun.serve>;
@@ -44,6 +175,25 @@ export interface CortexServer {
 }
 
 export function createServer(config: CortexConfig): CortexServer {
+  async function handleRequest(req: Request): Promise<Response> {
+    try {
+      const url = new URL(req.url);
+
+      if (req.method === "GET" && url.pathname === "/health") {
+        return handleHealth();
+      }
+
+      if (req.method === "POST" && url.pathname === "/ingest") {
+        return handleIngest(req, config);
+      }
+
+      return jsonResponse({ error: "not_found" }, 404);
+    } catch (err) {
+      console.error("Unhandled error in request handler:", err);
+      return jsonResponse({ error: "internal_error" }, 500);
+    }
+  }
+
   return {
     config,
     start() {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -32,7 +32,7 @@ describe("config", () => {
 
   test("returns defaults when no config file exists", () => {
     process.env.CORTEX_CONFIG_PATH = "/nonexistent/config.json";
-    const config = loadConfig({ quiet: true });
+    const config = loadConfig({ quiet: true, skipRequiredChecks: true });
 
     expect(config.host).toBe("127.0.0.1");
     expect(config.port).toBe(7751);
@@ -68,7 +68,7 @@ describe("config", () => {
     );
 
     process.env.CORTEX_CONFIG_PATH = configPath;
-    const config = loadConfig({ quiet: true });
+    const config = loadConfig({ quiet: true, skipRequiredChecks: true });
 
     expect(config.port).toBe(9999);
     expect(config.host).toBe("0.0.0.0");
@@ -111,7 +111,7 @@ describe("config", () => {
     );
 
     process.env.CORTEX_CONFIG_PATH = configPath;
-    const config = loadConfig({ quiet: true });
+    const config = loadConfig({ quiet: true, skipRequiredChecks: true });
 
     expect(config.synapseUrl).toBe("http://remote:7750");
 
@@ -123,7 +123,7 @@ describe("config", () => {
     process.env.CORTEX_CONFIG_PATH = "/nonexistent/config.json";
     process.env.CORTEX_PORT = "99999";
 
-    expect(() => loadConfig({ quiet: true })).toThrow(
+    expect(() => loadConfig({ quiet: true, skipRequiredChecks: true })).toThrow(
       "not a valid port number",
     );
   });
@@ -135,7 +135,7 @@ describe("config", () => {
     writeFileSync(configPath, JSON.stringify({ port: -1 }));
     process.env.CORTEX_CONFIG_PATH = configPath;
 
-    expect(() => loadConfig({ quiet: true })).toThrow(
+    expect(() => loadConfig({ quiet: true, skipRequiredChecks: true })).toThrow(
       "not a valid port number",
     );
 
@@ -149,7 +149,9 @@ describe("config", () => {
     writeFileSync(configPath, "not json");
     process.env.CORTEX_CONFIG_PATH = configPath;
 
-    expect(() => loadConfig({ quiet: true })).toThrow("invalid JSON");
+    expect(() => loadConfig({ quiet: true, skipRequiredChecks: true })).toThrow(
+      "invalid JSON",
+    );
 
     rmSync(tmpDir, { recursive: true });
   });
@@ -161,8 +163,18 @@ describe("config", () => {
     writeFileSync(configPath, JSON.stringify({ outboxLeaseSeconds: 5 }));
     process.env.CORTEX_CONFIG_PATH = configPath;
 
-    expect(() => loadConfig({ quiet: true })).toThrow("must be >= 10");
+    expect(() => loadConfig({ quiet: true, skipRequiredChecks: true })).toThrow(
+      "must be >= 10",
+    );
 
     rmSync(tmpDir, { recursive: true });
+  });
+
+  test("throws when ingestApiKey is missing", () => {
+    process.env.CORTEX_CONFIG_PATH = "/nonexistent/config.json";
+
+    expect(() => loadConfig({ quiet: true })).toThrow(
+      "ingestApiKey is required",
+    );
   });
 });

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -5,9 +5,13 @@ import { createServer } from "../src/server";
 describe("health endpoint", () => {
   let server: ReturnType<typeof Bun.serve>;
   let baseUrl: string;
+  const savedEnv: Record<string, string | undefined> = {};
 
   beforeAll(() => {
+    savedEnv.CORTEX_CONFIG_PATH = process.env.CORTEX_CONFIG_PATH;
+    savedEnv.CORTEX_INGEST_API_KEY = process.env.CORTEX_INGEST_API_KEY;
     process.env.CORTEX_CONFIG_PATH = "/nonexistent/config.json";
+    process.env.CORTEX_INGEST_API_KEY = "test-key";
     const config = loadConfig({ quiet: true });
     // Use port 0 for random available port in tests
     const cortexServer = createServer({ ...config, port: 0 });
@@ -17,6 +21,10 @@ describe("health endpoint", () => {
 
   afterAll(() => {
     server.stop();
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    }
   });
 
   test("GET /health returns healthy status", async () => {

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -1,0 +1,273 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { loadConfig } from "../src/config";
+import { closeDatabase, getDatabase, initDatabase } from "../src/db";
+import { createServer } from "../src/server";
+
+const API_KEY = "test-ingest-key";
+
+function validEvent(overrides?: Record<string, unknown>) {
+  return {
+    source: "telegram",
+    externalMessageId: `msg-${crypto.randomUUID()}`,
+    idempotencyKey: `tg:${crypto.randomUUID()}`,
+    topicKey: "chat-42:thread-root",
+    userId: "tg:998877",
+    text: "Hello, world",
+    occurredAt: "2026-02-15T20:30:00Z",
+    ...overrides,
+  };
+}
+
+describe("POST /ingest", () => {
+  let server: ReturnType<typeof Bun.serve>;
+  let baseUrl: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeAll(() => {
+    savedEnv.CORTEX_CONFIG_PATH = process.env.CORTEX_CONFIG_PATH;
+    savedEnv.CORTEX_INGEST_API_KEY = process.env.CORTEX_INGEST_API_KEY;
+    process.env.CORTEX_CONFIG_PATH = "/nonexistent/config.json";
+    process.env.CORTEX_INGEST_API_KEY = API_KEY;
+    initDatabase({ path: ":memory:", force: true });
+    const config = loadConfig({ quiet: true });
+    const cortexServer = createServer({ ...config, port: 0 });
+    server = cortexServer.start();
+    baseUrl = `http://${server.hostname}:${server.port}`;
+  });
+
+  afterAll(() => {
+    server.stop();
+    closeDatabase();
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    }
+  });
+
+  function post(body: unknown, token?: string) {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (token !== undefined) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+    return fetch(`${baseUrl}/ingest`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+  }
+
+  test("returns 202 for valid new event", async () => {
+    const response = await post(validEvent(), API_KEY);
+
+    expect(response.status).toBe(202);
+
+    const body = (await response.json()) as {
+      eventId: string;
+      status: string;
+    };
+    expect(body.status).toBe("queued");
+    expect(body.eventId).toMatch(/^evt_/);
+  });
+
+  test("returns 200 for duplicate event", async () => {
+    const event = validEvent();
+
+    const first = await post(event, API_KEY);
+    expect(first.status).toBe(202);
+    const firstBody = (await first.json()) as { eventId: string };
+
+    const second = await post(event, API_KEY);
+    expect(second.status).toBe(200);
+
+    const secondBody = (await second.json()) as {
+      eventId: string;
+      status: string;
+    };
+    expect(secondBody.status).toBe("duplicate_ignored");
+    expect(secondBody.eventId).toBe(firstBody.eventId);
+  });
+
+  test("returns 401 without auth header", async () => {
+    const response = await fetch(`${baseUrl}/ingest`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validEvent()),
+    });
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("unauthorized");
+  });
+
+  test("returns 401 with wrong token", async () => {
+    const response = await post(validEvent(), "wrong-key");
+
+    expect(response.status).toBe(401);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("unauthorized");
+  });
+
+  test("returns 400 for missing required fields", async () => {
+    const response = await post({ text: "hello" }, API_KEY);
+
+    expect(response.status).toBe(400);
+
+    const body = (await response.json()) as {
+      error: string;
+      details: string[];
+    };
+    expect(body.error).toBe("invalid_request");
+    expect(body.details.length).toBeGreaterThan(0);
+    expect(body.details.some((d: string) => d.includes("source"))).toBe(true);
+  });
+
+  test("returns 400 for empty required fields", async () => {
+    const response = await post(validEvent({ text: "" }), API_KEY);
+
+    expect(response.status).toBe(400);
+
+    const body = (await response.json()) as {
+      error: string;
+      details: string[];
+    };
+    expect(body.details.some((d: string) => d.includes("text"))).toBe(true);
+  });
+
+  test("persists message to database", async () => {
+    const event = validEvent();
+    const response = await post(event, API_KEY);
+    const { eventId } = (await response.json()) as { eventId: string };
+
+    const db = getDatabase();
+    const row = db
+      .prepare("SELECT * FROM inbox_messages WHERE id = $id")
+      .get({ $id: eventId }) as Record<string, unknown>;
+
+    expect(row).not.toBeNull();
+    expect(row.source).toBe(event.source);
+    expect(row.external_message_id).toBe(event.externalMessageId);
+    expect(row.topic_key).toBe(event.topicKey);
+    expect(row.user_id).toBe(event.userId);
+    expect(row.text).toBe(event.text);
+    expect(row.status).toBe("pending");
+    expect(typeof row.occurred_at).toBe("number");
+    expect(typeof row.created_at).toBe("number");
+  });
+
+  test("stores optional metadata", async () => {
+    const event = validEvent({
+      metadata: { chatId: "-100123", threadId: "9" },
+    });
+    const response = await post(event, API_KEY);
+    const { eventId } = (await response.json()) as { eventId: string };
+
+    const db = getDatabase();
+    const row = db
+      .prepare("SELECT metadata_json FROM inbox_messages WHERE id = $id")
+      .get({ $id: eventId }) as { metadata_json: string };
+
+    const parsed = JSON.parse(row.metadata_json);
+    expect(parsed.chatId).toBe("-100123");
+    expect(parsed.threadId).toBe("9");
+  });
+
+  test("duplicate does not create second row", async () => {
+    const event = validEvent();
+
+    await post(event, API_KEY);
+    await post(event, API_KEY);
+
+    const db = getDatabase();
+    const count = db
+      .prepare(
+        "SELECT COUNT(*) as cnt FROM inbox_messages WHERE source = $source AND external_message_id = $eid",
+      )
+      .get({
+        $source: event.source,
+        $eid: event.externalMessageId,
+      }) as { cnt: number };
+
+    expect(count.cnt).toBe(1);
+  });
+
+  test("different source with same externalMessageId creates separate rows", async () => {
+    const sharedMsgId = `msg-${crypto.randomUUID()}`;
+
+    const resp1 = await post(
+      validEvent({ source: "telegram", externalMessageId: sharedMsgId }),
+      API_KEY,
+    );
+    const resp2 = await post(
+      validEvent({ source: "slack", externalMessageId: sharedMsgId }),
+      API_KEY,
+    );
+
+    expect(resp1.status).toBe(202);
+    expect(resp2.status).toBe(202);
+
+    const body1 = (await resp1.json()) as { eventId: string };
+    const body2 = (await resp2.json()) as { eventId: string };
+    expect(body1.eventId).not.toBe(body2.eventId);
+  });
+
+  test("returns 400 for invalid occurredAt date", async () => {
+    const response = await post(
+      validEvent({ occurredAt: "not-a-date" }),
+      API_KEY,
+    );
+
+    expect(response.status).toBe(400);
+
+    const body = (await response.json()) as {
+      error: string;
+      details: string[];
+    };
+    expect(body.error).toBe("invalid_request");
+    expect(body.details.some((d: string) => d.includes("occurredAt"))).toBe(
+      true,
+    );
+  });
+
+  test("returns 400 for non-JSON request body", async () => {
+    const response = await fetch(`${baseUrl}/ingest`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${API_KEY}`,
+      },
+      body: "not json{{",
+    });
+
+    expect(response.status).toBe(400);
+
+    const body = (await response.json()) as {
+      error: string;
+      details: string[];
+    };
+    expect(body.error).toBe("invalid_request");
+    expect(body.details[0]).toBe("Request body must be valid JSON");
+  });
+
+  test("returns 400 for JSON array body", async () => {
+    const response = await post([1, 2, 3], API_KEY);
+
+    expect(response.status).toBe(400);
+
+    const body = (await response.json()) as {
+      error: string;
+      details: string[];
+    };
+    expect(body.error).toBe("invalid_request");
+    expect(body.details[0]).toBe("Request body must be a JSON object");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `POST /ingest` endpoint with Bearer token auth, request validation, dedup, and SQLite inbox persistence
- Makes `ingestApiKey` a required config field with env var override (`CORTEX_INGEST_API_KEY`)
- Initializes SQLite database in production entry point

## Details

### Endpoint: `POST /ingest`
- **Auth**: Bearer token with constant-time comparison (`crypto.timingSafeEqual`)
- **Validation**: Required fields (source, externalMessageId, idempotencyKey, topicKey, userId, text, occurredAt), ISO 8601 date check, non-object body rejection
- **Dedup**: Optimistic check on `(source, externalMessageId)` + UNIQUE constraint fallback for concurrent duplicates
- **Persistence**: `inbox_messages` table in SQLite with WAL mode, status tracking, and metadata JSON
- **Responses**: `202 queued`, `200 duplicate_ignored`, `401 unauthorized`, `400 invalid_request`

### Config
- `loadConfig` now uses function overloads: `skipRequiredChecks: true` returns `PartialCortexConfig` (honest type), default returns `CortexConfig`
- `DEFAULTS` typed as `Omit<CortexConfig, "ingestApiKey" | "model" | "extractionModel">` — no `as` cast hiding missing fields

### Hardening (from 4 review iterations)
- Top-level error boundary in `handleRequest` → `500 { error: "internal_error" }`
- `initDatabase({ force: true })` option for test isolation
- Test env save/restore in `afterAll` for both test suites

### Tests: 25 pass, 0 fail
- 13 ingest tests (happy path, dedup, auth, validation, persistence, metadata, edge cases)
- 9 config tests (defaults, file loading, env overrides, interpolation, validation errors)
- 3 health tests (status, 404, method check)

Closes #3