### PR TITLE
feat: Slice 3 — Outbox poll/ack + CLI commands

### DIFF
--- a/src/send.ts
+++ b/src/send.ts
@@ -1,0 +1,123 @@
+/**
+ * Send a message through Cortex and wait for the response.
+ *
+ * Acts as a mini-connector: POST /ingest → poll /outbox/poll → ack /outbox/ack.
+ * Used by `cortex send` CLI command and tests.
+ */
+
+const POLL_INTERVAL_MS = 500;
+const POLL_TIMEOUT_MS = 30_000;
+const SEND_SOURCE = "cli";
+
+export interface SendOptions {
+  baseUrl: string;
+  apiKey: string;
+  pollIntervalMs?: number;
+  pollTimeoutMs?: number;
+}
+
+/**
+ * Send a message to Cortex and wait for the assistant's response.
+ *
+ * 1. POST /ingest with source="cli"
+ * 2. Poll /outbox/poll for source="cli" until response appears
+ * 3. Ack via /outbox/ack
+ * 4. Return response text
+ *
+ * Throws on timeout, connection failure, or unexpected errors.
+ */
+export async function sendMessage(
+  text: string,
+  options: SendOptions,
+): Promise<string> {
+  const { baseUrl, apiKey } = options;
+  const pollInterval = options.pollIntervalMs ?? POLL_INTERVAL_MS;
+  const pollTimeout = options.pollTimeoutMs ?? POLL_TIMEOUT_MS;
+
+  const topicKey = `cli:${crypto.randomUUID()}`;
+  const externalMessageId = `cli-${crypto.randomUUID()}`;
+
+  // 1. Ingest
+  const ingestResponse = await fetch(`${baseUrl}/ingest`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      source: SEND_SOURCE,
+      externalMessageId,
+      idempotencyKey: `cli:${externalMessageId}`,
+      topicKey,
+      userId: "cli:local",
+      text,
+      occurredAt: new Date().toISOString(),
+    }),
+  });
+
+  if (!ingestResponse.ok) {
+    const body = await ingestResponse.text();
+    throw new Error(`Ingest failed (${ingestResponse.status}): ${body}`);
+  }
+
+  // 2. Poll outbox
+  const start = Date.now();
+
+  while (Date.now() - start < pollTimeout) {
+    await Bun.sleep(pollInterval);
+
+    const pollResponse = await fetch(`${baseUrl}/outbox/poll`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        source: SEND_SOURCE,
+        topicKey,
+        max: 1,
+        leaseSeconds: 30,
+      }),
+    });
+
+    if (!pollResponse.ok) {
+      const body = await pollResponse.text();
+      throw new Error(`Poll failed (${pollResponse.status}): ${body}`);
+    }
+
+    const pollBody = (await pollResponse.json()) as {
+      messages: Array<{
+        messageId: string;
+        leaseToken: string;
+        topicKey: string;
+        text: string;
+      }>;
+    };
+
+    if (pollBody.messages.length === 0) continue;
+
+    const match = pollBody.messages[0];
+
+    // 3. Ack
+    const ackResponse = await fetch(`${baseUrl}/outbox/ack`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        messageId: match.messageId,
+        leaseToken: match.leaseToken,
+      }),
+    });
+
+    if (!ackResponse.ok) {
+      const body = await ackResponse.text();
+      throw new Error(`Ack failed (${ackResponse.status}): ${body}`);
+    }
+
+    return match.text;
+  }
+
+  throw new Error(`Timed out after ${pollTimeout}ms waiting for response`);
+}

--- a/test/cli-commands.test.ts
+++ b/test/cli-commands.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  closeDatabase,
+  enqueueInboxMessage,
+  enqueueOutboxMessage,
+  initDatabase,
+  listInboxMessages,
+  listOutboxMessages,
+  purgeMessages,
+} from "../src/db";
+
+describe("list and purge operations", () => {
+  beforeEach(() => {
+    initDatabase({ path: ":memory:", force: true });
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  function seedInbox(text: string): string {
+    const id = crypto.randomUUID().slice(0, 8);
+    const result = enqueueInboxMessage({
+      source: "telegram",
+      externalMessageId: `msg-${id}`,
+      topicKey: "topic-1",
+      userId: "user-1",
+      text,
+      occurredAt: Date.now(),
+      idempotencyKey: `key-${id}`,
+    });
+    return result.eventId;
+  }
+
+  function seedOutbox(text: string): string {
+    return enqueueOutboxMessage({
+      source: "telegram",
+      topicKey: "topic-1",
+      text,
+    });
+  }
+
+  // --- listInboxMessages ---
+
+  describe("listInboxMessages", () => {
+    test("returns empty array when no messages exist", () => {
+      const messages = listInboxMessages();
+      expect(messages).toHaveLength(0);
+    });
+
+    test("returns messages ordered by created_at DESC (most recent first)", async () => {
+      seedInbox("First");
+      await Bun.sleep(5);
+      seedInbox("Second");
+      await Bun.sleep(5);
+      seedInbox("Third");
+
+      const messages = listInboxMessages();
+      expect(messages).toHaveLength(3);
+      expect(messages[0].text).toBe("Third");
+      expect(messages[1].text).toBe("Second");
+      expect(messages[2].text).toBe("First");
+    });
+
+    test("respects limit parameter", async () => {
+      seedInbox("One");
+      await Bun.sleep(5);
+      seedInbox("Two");
+      await Bun.sleep(5);
+      seedInbox("Three");
+
+      const messages = listInboxMessages(2);
+      expect(messages).toHaveLength(2);
+      expect(messages[0].text).toBe("Three");
+      expect(messages[1].text).toBe("Two");
+    });
+
+    test("returns all fields", () => {
+      seedInbox("Hello");
+
+      const messages = listInboxMessages();
+      expect(messages).toHaveLength(1);
+      const msg = messages[0];
+      expect(msg.id).toMatch(/^evt_/);
+      expect(msg.source).toBe("telegram");
+      expect(msg.topic_key).toBe("topic-1");
+      expect(msg.user_id).toBe("user-1");
+      expect(msg.text).toBe("Hello");
+      expect(msg.status).toBe("pending");
+      expect(typeof msg.created_at).toBe("number");
+    });
+  });
+
+  // --- listOutboxMessages ---
+
+  describe("listOutboxMessages", () => {
+    test("returns empty array when no messages exist", () => {
+      const messages = listOutboxMessages();
+      expect(messages).toHaveLength(0);
+    });
+
+    test("returns messages ordered by created_at DESC (most recent first)", async () => {
+      seedOutbox("First");
+      await Bun.sleep(5);
+      seedOutbox("Second");
+      await Bun.sleep(5);
+      seedOutbox("Third");
+
+      const messages = listOutboxMessages();
+      expect(messages).toHaveLength(3);
+      expect(messages[0].text).toBe("Third");
+      expect(messages[1].text).toBe("Second");
+      expect(messages[2].text).toBe("First");
+    });
+
+    test("respects limit parameter", async () => {
+      seedOutbox("One");
+      await Bun.sleep(5);
+      seedOutbox("Two");
+      await Bun.sleep(5);
+      seedOutbox("Three");
+
+      const messages = listOutboxMessages(2);
+      expect(messages).toHaveLength(2);
+    });
+
+    test("returns all fields", () => {
+      seedOutbox("Reply");
+
+      const messages = listOutboxMessages();
+      expect(messages).toHaveLength(1);
+      const msg = messages[0];
+      expect(msg.id).toMatch(/^out_/);
+      expect(msg.source).toBe("telegram");
+      expect(msg.topic_key).toBe("topic-1");
+      expect(msg.text).toBe("Reply");
+      expect(msg.status).toBe("pending");
+      expect(msg.attempts).toBe(0);
+      expect(typeof msg.created_at).toBe("number");
+    });
+  });
+
+  // --- purgeMessages ---
+
+  describe("purgeMessages", () => {
+    test("returns zero counts on empty database", () => {
+      const counts = purgeMessages();
+      expect(counts.inbox).toBe(0);
+      expect(counts.outbox).toBe(0);
+    });
+
+    test("deletes all inbox and outbox messages", () => {
+      seedInbox("Inbox 1");
+      seedInbox("Inbox 2");
+      seedOutbox("Outbox 1");
+      seedOutbox("Outbox 2");
+      seedOutbox("Outbox 3");
+
+      const counts = purgeMessages();
+      expect(counts.inbox).toBe(2);
+      expect(counts.outbox).toBe(3);
+
+      // Verify they're actually gone
+      expect(listInboxMessages()).toHaveLength(0);
+      expect(listOutboxMessages()).toHaveLength(0);
+    });
+
+    test("can purge inbox only when outbox is empty", () => {
+      seedInbox("Inbox 1");
+
+      const counts = purgeMessages();
+      expect(counts.inbox).toBe(1);
+      expect(counts.outbox).toBe(0);
+    });
+
+    test("is idempotent — purging twice returns zero on second call", () => {
+      seedInbox("Inbox 1");
+      seedOutbox("Outbox 1");
+
+      purgeMessages();
+      const counts = purgeMessages();
+      expect(counts.inbox).toBe(0);
+      expect(counts.outbox).toBe(0);
+    });
+  });
+});

--- a/test/cli-send.test.ts
+++ b/test/cli-send.test.ts
@@ -1,0 +1,197 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import type { CortexConfig } from "../src/config";
+import { closeDatabase, initDatabase } from "../src/db";
+import { startProcessingLoop } from "../src/loop";
+import { sendMessage } from "../src/send";
+import { createServer } from "../src/server";
+
+// --- Mock Synapse server ---
+
+let mockSynapse: ReturnType<typeof Bun.serve>;
+let mockSynapseUrl: string;
+let mockHandler: (req: Request) => Response | Promise<Response>;
+
+beforeAll(() => {
+  mockHandler = () =>
+    Response.json({ error: "no mock configured" }, { status: 500 });
+
+  mockSynapse = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req) {
+      return mockHandler(req);
+    },
+  });
+
+  mockSynapseUrl = `http://127.0.0.1:${mockSynapse.port}`;
+});
+
+afterAll(() => {
+  mockSynapse.stop(true);
+});
+
+// --- Helpers ---
+
+const API_KEY = "test-send-key";
+
+function testConfig(port: number): CortexConfig {
+  return {
+    host: "127.0.0.1",
+    port,
+    ingestApiKey: API_KEY,
+    synapseUrl: mockSynapseUrl,
+    engramUrl: "http://localhost:7749",
+    model: "test-model",
+    activeWindowSize: 10,
+    extractionInterval: 3,
+    turnTtlDays: 30,
+    schedulerTickSeconds: 30,
+    schedulerTimezone: "UTC",
+    outboxPollDefaultBatch: 20,
+    outboxLeaseSeconds: 60,
+    outboxMaxAttempts: 10,
+    skillDirs: [],
+    toolTimeoutMs: 20000,
+  };
+}
+
+function openaiResponse(content: string) {
+  return {
+    id: "chat-test",
+    object: "chat.completion",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+  };
+}
+
+// --- Tests ---
+
+describe("sendMessage (end-to-end)", () => {
+  let cortexServer: ReturnType<typeof Bun.serve>;
+  let loop: { stop: () => Promise<void> };
+  let baseUrl: string;
+  let config: CortexConfig;
+
+  beforeAll(() => {
+    initDatabase({ path: ":memory:", force: true });
+    config = testConfig(0);
+    const server = createServer(config);
+    cortexServer = server.start();
+    baseUrl = `http://${cortexServer.hostname}:${cortexServer.port}`;
+  });
+
+  afterAll(() => {
+    cortexServer.stop(true);
+    closeDatabase();
+  });
+
+  beforeEach(() => {
+    initDatabase({ path: ":memory:", force: true });
+    loop = startProcessingLoop(
+      { ...config, port: cortexServer.port as number },
+      { pollBusyMs: 10, pollIdleMs: 50 },
+    );
+  });
+
+  afterEach(async () => {
+    await loop.stop();
+  });
+
+  test("full round-trip: ingest → loop → synapse → outbox → poll → ack", async () => {
+    mockHandler = () =>
+      Response.json(openaiResponse("Hello from the assistant!"));
+
+    const response = await sendMessage("What is 2+2?", {
+      baseUrl,
+      apiKey: API_KEY,
+      pollIntervalMs: 100,
+      pollTimeoutMs: 10_000,
+    });
+
+    expect(response).toBe("Hello from the assistant!");
+  });
+
+  test("returns correct response for different messages", async () => {
+    mockHandler = async (req) => {
+      const body = (await req.json()) as {
+        messages: Array<{ content: string }>;
+      };
+      const userMsg = body.messages[body.messages.length - 1].content;
+      return Response.json(openaiResponse(`Echo: ${userMsg}`));
+    };
+
+    const response = await sendMessage("ping", {
+      baseUrl,
+      apiKey: API_KEY,
+      pollIntervalMs: 100,
+      pollTimeoutMs: 10_000,
+    });
+
+    expect(response).toBe("Echo: ping");
+  });
+
+  test("times out when no response is produced", async () => {
+    // Synapse returns an error, so the loop marks inbox as failed
+    // but no outbox message is written — sendMessage never finds a response
+    mockHandler = () =>
+      Response.json(
+        { error: { message: "model unavailable", type: "server_error" } },
+        { status: 503 },
+      );
+
+    const promise = sendMessage("Will timeout", {
+      baseUrl,
+      apiKey: API_KEY,
+      pollIntervalMs: 50,
+      pollTimeoutMs: 500,
+    });
+
+    await expect(promise).rejects.toThrow("Timed out");
+  });
+
+  test("throws on connection failure", async () => {
+    const promise = sendMessage("Hello", {
+      baseUrl: "http://localhost:1",
+      apiKey: API_KEY,
+      pollIntervalMs: 100,
+      pollTimeoutMs: 1_000,
+    });
+
+    await expect(promise).rejects.toThrow();
+  });
+
+  test("handles multiple sequential sends", async () => {
+    let callCount = 0;
+    mockHandler = () => {
+      callCount++;
+      return Response.json(openaiResponse(`Response ${callCount}`));
+    };
+
+    const opts = {
+      baseUrl,
+      apiKey: API_KEY,
+      pollIntervalMs: 100,
+      pollTimeoutMs: 10_000,
+    };
+
+    const r1 = await sendMessage("First", opts);
+    const r2 = await sendMessage("Second", opts);
+
+    expect(r1).toBe("Response 1");
+    expect(r2).toBe("Response 2");
+  });
+});

--- a/test/loop.test.ts
+++ b/test/loop.test.ts
@@ -121,6 +121,9 @@ async function waitFor(
   }
 }
 
+/** Fast poll intervals for tests — avoids 2s idle sleep. */
+const FAST_LOOP = { pollBusyMs: 10, pollIdleMs: 50 };
+
 // --- Tests ---
 
 describe("processing loop", () => {
@@ -138,7 +141,7 @@ describe("processing loop", () => {
 
     const { eventId } = ingestMessage({ text: "Hello assistant" });
     const config = testConfig();
-    const loop = startProcessingLoop(config);
+    const loop = startProcessingLoop(config, FAST_LOOP);
 
     await waitFor(() => {
       const msg = getInboxMessage(eventId);
@@ -170,7 +173,7 @@ describe("processing loop", () => {
     };
 
     ingestMessage({ text: "What is 2+2?" });
-    const loop = startProcessingLoop(testConfig());
+    const loop = startProcessingLoop(testConfig(), FAST_LOOP);
 
     await waitFor(() => mockCallCount > 0);
     await loop.stop();
@@ -212,7 +215,7 @@ describe("processing loop", () => {
       topicKey: "topic-a",
     });
 
-    const loop = startProcessingLoop(testConfig());
+    const loop = startProcessingLoop(testConfig(), FAST_LOOP);
 
     await waitFor(() => {
       const msg = getInboxMessage(id2);
@@ -252,7 +255,7 @@ describe("processing loop", () => {
       topicKey: "topic-b",
     });
 
-    const loop = startProcessingLoop(testConfig());
+    const loop = startProcessingLoop(testConfig(), FAST_LOOP);
 
     await waitFor(() => {
       const a = getInboxMessage(id1);
@@ -280,7 +283,7 @@ describe("processing loop", () => {
       );
 
     const { eventId } = ingestMessage({ text: "Will fail" });
-    const loop = startProcessingLoop(testConfig());
+    const loop = startProcessingLoop(testConfig(), FAST_LOOP);
 
     await waitFor(() => {
       const msg = getInboxMessage(eventId);
@@ -301,7 +304,7 @@ describe("processing loop", () => {
   test("loop stops gracefully without errors when inbox is empty", async () => {
     mockHandler = () => Response.json(openaiResponse("should not be called"));
 
-    const loop = startProcessingLoop(testConfig());
+    const loop = startProcessingLoop(testConfig(), FAST_LOOP);
 
     // Let it tick a couple of times on empty inbox
     await Bun.sleep(200);
@@ -332,7 +335,7 @@ describe("processing loop", () => {
       externalMessageId: "msg-success",
     });
 
-    const loop = startProcessingLoop(testConfig());
+    const loop = startProcessingLoop(testConfig(), FAST_LOOP);
 
     await waitFor(() => {
       const msg = getInboxMessage(successId);

--- a/test/outbox-ack.test.ts
+++ b/test/outbox-ack.test.ts
@@ -1,0 +1,236 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { loadConfig } from "../src/config";
+import {
+  closeDatabase,
+  enqueueOutboxMessage,
+  getDatabase,
+  getOutboxMessage,
+  initDatabase,
+  pollOutboxMessages,
+} from "../src/db";
+import { createServer } from "../src/server";
+
+const API_KEY = "test-ack-key";
+
+describe("POST /outbox/ack", () => {
+  let server: ReturnType<typeof Bun.serve>;
+  let baseUrl: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeAll(() => {
+    savedEnv.CORTEX_CONFIG_PATH = process.env.CORTEX_CONFIG_PATH;
+    process.env.CORTEX_CONFIG_PATH = "/nonexistent/config.json";
+    initDatabase({ path: ":memory:", force: true });
+    const config = loadConfig({ quiet: true, skipRequiredChecks: true });
+    const cortexServer = createServer({
+      ...config,
+      port: 0,
+      ingestApiKey: API_KEY,
+      model: "test-model",
+    });
+    server = cortexServer.start();
+    baseUrl = `http://${server.hostname}:${server.port}`;
+  });
+
+  afterAll(() => {
+    server.stop(true);
+    closeDatabase();
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    }
+  });
+
+  beforeEach(() => {
+    initDatabase({ path: ":memory:", force: true });
+  });
+
+  function post(body: unknown, token?: string) {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (token !== undefined) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+    return fetch(`${baseUrl}/outbox/ack`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+  }
+
+  /** Seed an outbox message and claim it, returning messageId + leaseToken. */
+  function seedAndClaim(): { messageId: string; leaseToken: string } {
+    const outboxId = enqueueOutboxMessage({
+      source: "telegram",
+      topicKey: "topic-1",
+      text: "Hello",
+    });
+
+    const results = pollOutboxMessages("telegram", 1, 60, 10);
+    expect(results).toHaveLength(1);
+    expect(results[0].messageId).toBe(outboxId);
+
+    return {
+      messageId: results[0].messageId,
+      leaseToken: results[0].leaseToken,
+    };
+  }
+
+  // --- Auth ---
+
+  test("returns 401 without auth header", async () => {
+    const response = await fetch(`${baseUrl}/outbox/ack`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messageId: "out_123", leaseToken: "lease_abc" }),
+    });
+    expect(response.status).toBe(401);
+  });
+
+  test("returns 401 with wrong token", async () => {
+    const response = await post(
+      { messageId: "out_123", leaseToken: "lease_abc" },
+      "wrong-key",
+    );
+    expect(response.status).toBe(401);
+  });
+
+  // --- Validation ---
+
+  test("returns 400 when messageId is missing", async () => {
+    const response = await post({ leaseToken: "lease_abc" }, API_KEY);
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { details: string[] };
+    expect(body.details.some((d: string) => d.includes("messageId"))).toBe(
+      true,
+    );
+  });
+
+  test("returns 400 when leaseToken is missing", async () => {
+    const response = await post({ messageId: "out_123" }, API_KEY);
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { details: string[] };
+    expect(body.details.some((d: string) => d.includes("leaseToken"))).toBe(
+      true,
+    );
+  });
+
+  test("returns 400 when both fields are missing", async () => {
+    const response = await post({}, API_KEY);
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { details: string[] };
+    expect(body.details).toHaveLength(2);
+  });
+
+  test("returns 400 for non-JSON body", async () => {
+    const response = await fetch(`${baseUrl}/outbox/ack`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${API_KEY}`,
+      },
+      body: "not json",
+    });
+    expect(response.status).toBe(400);
+  });
+
+  // --- Successful ack ---
+
+  test("acks a leased message successfully", async () => {
+    const { messageId, leaseToken } = seedAndClaim();
+
+    const response = await post({ messageId, leaseToken }, API_KEY);
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as { ok: boolean; status: string };
+    expect(body.ok).toBe(true);
+    expect(body.status).toBe("delivered");
+
+    // Row should be delivered
+    const row = getOutboxMessage(messageId);
+    expect(row!.status).toBe("delivered");
+  });
+
+  test("idempotent re-ack returns already_delivered", async () => {
+    const { messageId, leaseToken } = seedAndClaim();
+
+    // First ack
+    await post({ messageId, leaseToken }, API_KEY);
+
+    // Second ack — idempotent
+    const response = await post({ messageId, leaseToken }, API_KEY);
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as { ok: boolean; status: string };
+    expect(body.ok).toBe(true);
+    expect(body.status).toBe("already_delivered");
+  });
+
+  // --- Conflict cases ---
+
+  test("returns 409 for wrong lease token", async () => {
+    const { messageId } = seedAndClaim();
+
+    const response = await post(
+      { messageId, leaseToken: "lease_wrong" },
+      API_KEY,
+    );
+    expect(response.status).toBe(409);
+
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("lease_conflict");
+  });
+
+  test("returns 409 for expired lease", async () => {
+    const { messageId, leaseToken } = seedAndClaim();
+
+    // Manually expire the lease
+    const db = getDatabase();
+    const past = Date.now() - 60_000;
+    db.prepare(
+      "UPDATE outbox_messages SET lease_expires_at = $past WHERE id = $id",
+    ).run({ $past: past, $id: messageId });
+
+    const response = await post({ messageId, leaseToken }, API_KEY);
+    expect(response.status).toBe(409);
+
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("lease_conflict");
+  });
+
+  test("returns 409 when acking a delivered message with different token", async () => {
+    const { messageId, leaseToken } = seedAndClaim();
+
+    // Ack successfully first
+    await post({ messageId, leaseToken }, API_KEY);
+
+    // Try acking again with a different token
+    const response = await post(
+      { messageId, leaseToken: "lease_different" },
+      API_KEY,
+    );
+    expect(response.status).toBe(409);
+  });
+
+  // --- Not found ---
+
+  test("returns 404 for non-existent messageId", async () => {
+    const response = await post(
+      { messageId: "out_nonexistent", leaseToken: "lease_abc" },
+      API_KEY,
+    );
+    expect(response.status).toBe(404);
+
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("not_found");
+  });
+});

--- a/test/outbox-poll.test.ts
+++ b/test/outbox-poll.test.ts
@@ -1,0 +1,377 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { loadConfig } from "../src/config";
+import {
+  closeDatabase,
+  computeBackoffDelay,
+  enqueueOutboxMessage,
+  getDatabase,
+  getOutboxMessage,
+  initDatabase,
+} from "../src/db";
+import { createServer } from "../src/server";
+
+const API_KEY = "test-poll-key";
+
+describe("computeBackoffDelay", () => {
+  test("returns ~5s for first attempt", () => {
+    const delays: number[] = [];
+    for (let i = 0; i < 100; i++) {
+      delays.push(computeBackoffDelay(1));
+    }
+    // 5000 * [0.8, 1.2] = [4000, 6000]
+    for (const d of delays) {
+      expect(d).toBeGreaterThanOrEqual(4000);
+      expect(d).toBeLessThanOrEqual(6000);
+    }
+  });
+
+  test("doubles delay with each attempt", () => {
+    // Run many samples and check medians increase
+    const medianFor = (attempts: number) => {
+      const samples = Array.from({ length: 50 }, () =>
+        computeBackoffDelay(attempts),
+      );
+      samples.sort((a, b) => a - b);
+      return samples[25];
+    };
+
+    const m1 = medianFor(1);
+    const m2 = medianFor(2);
+    const m3 = medianFor(3);
+
+    expect(m2).toBeGreaterThan(m1 * 1.5);
+    expect(m3).toBeGreaterThan(m2 * 1.5);
+  });
+
+  test("caps at 15 minutes (900000ms)", () => {
+    const delays: number[] = [];
+    for (let i = 0; i < 50; i++) {
+      delays.push(computeBackoffDelay(20));
+    }
+    // 900000 * 1.2 = 1080000
+    for (const d of delays) {
+      expect(d).toBeLessThanOrEqual(1_080_000);
+      expect(d).toBeGreaterThanOrEqual(720_000); // 900000 * 0.8
+    }
+  });
+});
+
+describe("POST /outbox/poll", () => {
+  let server: ReturnType<typeof Bun.serve>;
+  let baseUrl: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeAll(() => {
+    savedEnv.CORTEX_CONFIG_PATH = process.env.CORTEX_CONFIG_PATH;
+    process.env.CORTEX_CONFIG_PATH = "/nonexistent/config.json";
+    initDatabase({ path: ":memory:", force: true });
+    const config = loadConfig({ quiet: true, skipRequiredChecks: true });
+    const cortexServer = createServer({
+      ...config,
+      port: 0,
+      ingestApiKey: API_KEY,
+      model: "test-model",
+    });
+    server = cortexServer.start();
+    baseUrl = `http://${server.hostname}:${server.port}`;
+  });
+
+  afterAll(() => {
+    server.stop(true);
+    closeDatabase();
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    }
+  });
+
+  beforeEach(() => {
+    initDatabase({ path: ":memory:", force: true });
+  });
+
+  function post(body: unknown, token?: string) {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (token !== undefined) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+    return fetch(`${baseUrl}/outbox/poll`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    });
+  }
+
+  function seedOutbox(
+    overrides: Partial<{
+      source: string;
+      topicKey: string;
+      text: string;
+    }> = {},
+  ): string {
+    return enqueueOutboxMessage({
+      source: overrides.source ?? "telegram",
+      topicKey: overrides.topicKey ?? "topic-1",
+      text: overrides.text ?? "Hello from assistant",
+    });
+  }
+
+  // --- Auth ---
+
+  test("returns 401 without auth header", async () => {
+    const response = await fetch(`${baseUrl}/outbox/poll`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ source: "telegram" }),
+    });
+    expect(response.status).toBe(401);
+  });
+
+  test("returns 401 with wrong token", async () => {
+    const response = await post({ source: "telegram" }, "wrong-key");
+    expect(response.status).toBe(401);
+  });
+
+  // --- Validation ---
+
+  test("returns 400 when source is missing", async () => {
+    const response = await post({}, API_KEY);
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { details: string[] };
+    expect(body.details.some((d: string) => d.includes("source"))).toBe(true);
+  });
+
+  test("returns 400 when source is empty string", async () => {
+    const response = await post({ source: "" }, API_KEY);
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { details: string[] };
+    expect(body.details.some((d: string) => d.includes("source"))).toBe(true);
+  });
+
+  test("returns 400 when max is out of range", async () => {
+    const response = await post({ source: "telegram", max: 200 }, API_KEY);
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { details: string[] };
+    expect(body.details.some((d: string) => d.includes("max"))).toBe(true);
+  });
+
+  test("returns 400 when max is zero", async () => {
+    const response = await post({ source: "telegram", max: 0 }, API_KEY);
+    expect(response.status).toBe(400);
+  });
+
+  test("returns 400 when leaseSeconds is out of range", async () => {
+    const response = await post(
+      { source: "telegram", leaseSeconds: 5 },
+      API_KEY,
+    );
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { details: string[] };
+    expect(body.details.some((d: string) => d.includes("leaseSeconds"))).toBe(
+      true,
+    );
+  });
+
+  test("returns 400 for non-JSON body", async () => {
+    const response = await fetch(`${baseUrl}/outbox/poll`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${API_KEY}`,
+      },
+      body: "not json",
+    });
+    expect(response.status).toBe(400);
+  });
+
+  test("returns 400 for JSON array body", async () => {
+    const response = await post([1, 2, 3], API_KEY);
+    expect(response.status).toBe(400);
+  });
+
+  // --- Empty results ---
+
+  test("returns empty messages array when no outbox messages exist", async () => {
+    const response = await post({ source: "telegram" }, API_KEY);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      messages: unknown[];
+    };
+    expect(body.messages).toHaveLength(0);
+  });
+
+  test("returns empty when source does not match", async () => {
+    seedOutbox({ source: "telegram" });
+
+    const response = await post({ source: "slack" }, API_KEY);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { messages: unknown[] };
+    expect(body.messages).toHaveLength(0);
+  });
+
+  // --- Successful claims ---
+
+  test("claims a single pending outbox message", async () => {
+    const outboxId = seedOutbox();
+
+    const response = await post({ source: "telegram" }, API_KEY);
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      messages: Array<{
+        messageId: string;
+        leaseToken: string;
+        topicKey: string;
+        text: string;
+        payload: unknown;
+      }>;
+    };
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].messageId).toBe(outboxId);
+    expect(body.messages[0].leaseToken).toMatch(/^lease_/);
+    expect(body.messages[0].topicKey).toBe("topic-1");
+    expect(body.messages[0].text).toBe("Hello from assistant");
+    expect(body.messages[0].payload).toBeNull();
+  });
+
+  test("claims multiple messages up to max", async () => {
+    seedOutbox({ text: "msg 1" });
+    seedOutbox({ text: "msg 2" });
+    seedOutbox({ text: "msg 3" });
+
+    const response = await post({ source: "telegram", max: 2 }, API_KEY);
+    const body = (await response.json()) as {
+      messages: Array<{ text: string }>;
+    };
+    expect(body.messages).toHaveLength(2);
+  });
+
+  test("sets lease fields on claimed message", async () => {
+    const outboxId = seedOutbox();
+
+    await post({ source: "telegram", leaseSeconds: 30 }, API_KEY);
+
+    const row = getOutboxMessage(outboxId);
+    expect(row).not.toBeNull();
+    expect(row!.status).toBe("leased");
+    expect(row!.lease_token).toMatch(/^lease_/);
+    expect(row!.lease_expires_at).not.toBeNull();
+    expect(row!.attempts).toBe(1);
+  });
+
+  test("does not return already-leased messages with active lease", async () => {
+    seedOutbox();
+
+    // First poll claims the message
+    await post({ source: "telegram", leaseSeconds: 60 }, API_KEY);
+
+    // Second poll should find nothing (lease is active)
+    const response = await post({ source: "telegram" }, API_KEY);
+    const body = (await response.json()) as { messages: unknown[] };
+    expect(body.messages).toHaveLength(0);
+  });
+
+  test("reclaims message with expired lease", async () => {
+    const outboxId = seedOutbox();
+
+    // Claim with very short lease, then manually expire it
+    await post({ source: "telegram", leaseSeconds: 10 }, API_KEY);
+
+    // Manually expire the lease by backdating lease_expires_at and next_attempt_at
+    const db = getDatabase();
+    const past = Date.now() - 60_000;
+    db.prepare(
+      "UPDATE outbox_messages SET lease_expires_at = $past, next_attempt_at = $past WHERE id = $id",
+    ).run({ $past: past, $id: outboxId });
+
+    // Now poll again — should reclaim
+    const response = await post({ source: "telegram" }, API_KEY);
+    const body = (await response.json()) as {
+      messages: Array<{ messageId: string }>;
+    };
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].messageId).toBe(outboxId);
+
+    // Attempts should now be 2
+    const row = getOutboxMessage(outboxId);
+    expect(row!.attempts).toBe(2);
+  });
+
+  // --- DLQ ---
+
+  test("transitions to dead when attempts exceed maxAttempts", async () => {
+    const outboxId = seedOutbox();
+
+    // Manually set attempts to maxAttempts (10), so next claim would be 11 > 10
+    const db = getDatabase();
+    const past = Date.now() - 60_000;
+    db.prepare(
+      "UPDATE outbox_messages SET attempts = 10, status = 'leased', lease_expires_at = $past, next_attempt_at = $past WHERE id = $id",
+    ).run({ $past: past, $id: outboxId });
+
+    // Poll should DLQ it, not return it
+    const response = await post({ source: "telegram" }, API_KEY);
+    const body = (await response.json()) as { messages: unknown[] };
+    expect(body.messages).toHaveLength(0);
+
+    // Row should be dead
+    const row = getOutboxMessage(outboxId);
+    expect(row!.status).toBe("dead");
+    expect(row!.attempts).toBe(11);
+    expect(row!.last_error).toBe("max attempts exceeded");
+  });
+
+  // --- Backoff ---
+
+  test("sets next_attempt_at in the future for retries", async () => {
+    const outboxId = seedOutbox();
+
+    const before = Date.now();
+    await post({ source: "telegram" }, API_KEY);
+
+    const row = getOutboxMessage(outboxId);
+    expect(row).not.toBeNull();
+    // next_attempt_at should be in the future (backoff for attempt 1: ~4000-6000ms)
+    expect(row!.next_attempt_at).toBeGreaterThan(before);
+  });
+
+  // --- Payload ---
+
+  test("returns parsed payload from outbox message", async () => {
+    enqueueOutboxMessage({
+      source: "telegram",
+      topicKey: "topic-1",
+      text: "text with payload",
+      payload: { buttons: [{ label: "Yes" }] },
+    });
+
+    const response = await post({ source: "telegram" }, API_KEY);
+    const body = (await response.json()) as {
+      messages: Array<{ payload: { buttons: Array<{ label: string }> } }>;
+    };
+    expect(body.messages[0].payload).toEqual({
+      buttons: [{ label: "Yes" }],
+    });
+  });
+
+  // --- Defaults ---
+
+  test("uses config defaults when max and leaseSeconds are omitted", async () => {
+    seedOutbox();
+
+    // Should work with just source, using outboxPollDefaultBatch and outboxLeaseSeconds from config
+    const response = await post({ source: "telegram" }, API_KEY);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { messages: unknown[] };
+    expect(body.messages).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Implements connector delivery handoff and CLI tooling for end-to-end testing. Closes #5.

- **POST /outbox/poll**: Lease-based claim with source + optional topicKey filtering, exponential backoff (5s base, 15min cap, ±20% jitter), dead-letter at `maxAttempts`
- **POST /outbox/ack**: Lease verification with idempotent re-ack, transactional read-modify-write with defensive WHERE guards
- **cortex send "msg"**: Round-trip test tool — ingest → poll → ack, acts as a mini-connector
- **cortex inbox / outbox**: Show recent messages with status, source, topic, timestamps
- **cortex purge --confirm**: Wipe inbox + outbox tables for dev cleanup
- **Configurable loop poll intervals**: Tests use fast intervals (13.5s → 1.9s suite time)

## Key decisions

- Poll/ack endpoints require Bearer auth (same key as ingest)
- `cortex send` uses fixed source `"cli"` with random topic per invocation
- `cortex send` polls via HTTP endpoints (not direct DB), testing the real delivery path
- `cortex inbox` / `outbox` / `purge` connect to DB directly (no daemon required)
- Backoff `next_attempt_at` set at claim time — if ack succeeds, value is irrelevant; if lease expires, backoff naturally gates re-eligibility
- `ackOutboxMessage` checks UPDATE `changes === 1` for defense-in-depth
- Dead-lettered messages record `last_error = "max attempts exceeded"`

## Review hardening (5 rounds)

1. `pollOutboxMessages` accepts optional `topicKey` — prevents `sendMessage` from silently consuming unrelated outbox messages
2. `ackOutboxMessage` wrapped in transaction with defensive WHERE guards + changes check
3. `purgeMessages` wrapped in transaction for atomic cleanup
4. CLI commands use try/finally for `closeDatabase()` cleanup
5. Dead-letter records `last_error` for observability
6. Restored `cortex version` in CLI help text

## Test coverage

**97 tests, 558 assertions** (up from 45/134 in Slice 2)

| File | Tests | Coverage |
|------|-------|----------|
| `outbox-poll.test.ts` | 23 | Backoff math, auth, validation, claims, batching, lease fields, expired lease reclaim, DLQ, payload, defaults |
| `outbox-ack.test.ts` | 12 | Auth, validation, successful ack, idempotent re-ack, wrong token, expired lease, not found |
| `cli-commands.test.ts` | 12 | List inbox/outbox ordering, limits, fields, purge counts, idempotency |
| `cli-send.test.ts` | 5 | Full end-to-end round-trip, echo, timeout, connection failure, sequential sends |

## Files changed

| File | Change |
|------|--------|
| `src/db.ts` | +241: computeBackoffDelay, pollOutboxMessages, ackOutboxMessage, listInboxMessages, listOutboxMessages, purgeMessages |
| `src/server.ts` | +186: POST /outbox/poll + POST /outbox/ack routes with auth + validation |
| `src/cli.ts` | +193: send, inbox, outbox, purge commands |
| `src/send.ts` | NEW: sendMessage() extracted function |
| `src/loop.ts` | +13: configurable poll intervals via ProcessingLoopOptions |
| `test/` | 4 new test files |