### PR TITLE
feat: operational logging and createLogsCommand from core

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "cortex",
       "dependencies": {
-        "@shetty4l/core": ">=0.1.0 <1.0.0",
+        "@shetty4l/core": "^0.1.18",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.13",
@@ -51,7 +51,7 @@
 
     "@oxlint/win32-x64": ["@oxlint/win32-x64@0.12.0", "", { "os": "win32", "cpu": "x64" }, "sha512-NHLJolo4sZk3nu/bPNuaJ+6p5DdHoRuZAjyuSO6CnLgpmZcYqx7LgngA/x2oB/bLgi4Hv9twjHjODc5Ce5o14g=="],
 
-    "@shetty4l/core": ["@shetty4l/core@0.1.17", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-OkgMYxF5273YTMqNMiE+LDix33ESrP9MI8XeNbTDEHBPc+0Gf5CrUgV/dmPIggjiAUT+zLLO/Asdb2o262lrgQ=="],
+    "@shetty4l/core": ["@shetty4l/core@0.1.18", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-lMZ//FvhD6Uu8bWM75fwPd6A412zrZp3CPXxlNeFZr6VtiVh9Ua+LqkrBm7t4CDUrXDOr+AezpR+xfvkCThnAA=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,12 +26,11 @@
  */
 
 import type { CommandHandler } from "@shetty4l/core/cli";
-import { formatUptime, runCli } from "@shetty4l/core/cli";
+import { createLogsCommand, formatUptime, runCli } from "@shetty4l/core/cli";
 import { getConfigDir } from "@shetty4l/core/config";
 import { createDaemonManager } from "@shetty4l/core/daemon";
 import { onShutdown } from "@shetty4l/core/signals";
 import { readVersion } from "@shetty4l/core/version";
-import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { loadConfig } from "./config";
 import {
@@ -258,48 +257,10 @@ function cmdConfig(_args: string[], json: boolean): number {
   return 0;
 }
 
-function cmdLogs(args: string[], json: boolean): number {
-  const count = args[0] ? Number.parseInt(args[0], 10) : 20;
-
-  if (Number.isNaN(count) || count < 1) {
-    console.error("Error: count must be a positive number");
-    return 1;
-  }
-
-  if (!existsSync(LOG_FILE)) {
-    if (json) {
-      console.log(JSON.stringify({ lines: [], count: 0 }));
-    } else {
-      console.log("No logs found.");
-    }
-    return 0;
-  }
-
-  const content = readFileSync(LOG_FILE, "utf-8").trimEnd();
-  if (content.length === 0) {
-    if (json) {
-      console.log(JSON.stringify({ lines: [], count: 0 }));
-    } else {
-      console.log("No logs found.");
-    }
-    return 0;
-  }
-
-  const lines = content.split("\n");
-  const tail = lines.slice(-count);
-
-  if (json) {
-    console.log(JSON.stringify({ lines: tail, count: tail.length }, null, 2));
-    return 0;
-  }
-
-  for (const line of tail) {
-    console.log(line);
-  }
-
-  console.log(`\nShowing ${tail.length} of ${lines.length} lines`);
-  return 0;
-}
+const cmdLogs = createLogsCommand({
+  logFile: LOG_FILE,
+  emptyMessage: "No logs found.",
+});
 
 // --- Inbox/outbox/purge/send commands ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ if (!dbResult.ok) {
 }
 
 const server = startServer(config);
+console.error(`cortex: listening on http://${config.host}:${config.port}`);
 const loop = startProcessingLoop(config);
 console.error("cortex: processing loop started");
 


### PR DESCRIPTION
## Summary
- **loop.ts**: 3 log lines per message — claimed (topic+preview), context summary (memories=N turns=N), result+timing (done/failed + Ns)
- **server.ts**: per-request access log to stderr (method path status latencyMs)
- **index.ts**: add listen address to startup output
- **cli.ts**: replace bespoke `cmdLogs` with `createLogsCommand` from `@shetty4l/core@0.1.18`

Human-readable `cortex:` prefix format. All operational logs go to stderr.