### PR TITLE
feat: add async fact extraction pipeline (Slice 5)

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -72,6 +72,12 @@ const SCHEMA = `
 
   CREATE INDEX IF NOT EXISTS idx_turns_topic_created
     ON turns(topic_key, created_at);
+
+  CREATE TABLE IF NOT EXISTS extraction_cursors (
+    topic_key TEXT PRIMARY KEY,
+    last_extracted_rowid INTEGER NOT NULL,
+    turns_since_extraction INTEGER NOT NULL DEFAULT 0
+  );
 `;
 
 // --- Connection (via core DatabaseManager) ---
@@ -647,4 +653,99 @@ export function loadRecentTurns(topicKey: string, limit = 8): Turn[] {
       ) ORDER BY rn ASC`,
     )
     .all({ $topicKey: topicKey, $maxRows: maxRows }) as Turn[];
+}
+
+// --- Extraction cursor operations ---
+
+export interface ExtractionCursor {
+  topic_key: string;
+  last_extracted_rowid: number;
+  turns_since_extraction: number;
+}
+
+/**
+ * Get the extraction cursor for a topic.
+ * Returns null if no extraction has ever run for this topic.
+ */
+export function getExtractionCursor(topicKey: string): ExtractionCursor | null {
+  const database = getDatabase();
+  return (
+    (database
+      .prepare(
+        "SELECT topic_key, last_extracted_rowid, turns_since_extraction FROM extraction_cursors WHERE topic_key = $topicKey",
+      )
+      .get({ $topicKey: topicKey }) as ExtractionCursor | null) ?? null
+  );
+}
+
+/**
+ * Increment the turns-since-extraction counter for a topic.
+ *
+ * If no cursor exists, creates one with last_extracted_rowid = 0
+ * and turns_since_extraction = 1 (first turn, no extraction yet).
+ */
+export function incrementTurnsSinceExtraction(topicKey: string): void {
+  const database = getDatabase();
+  database
+    .prepare(
+      `INSERT INTO extraction_cursors (topic_key, last_extracted_rowid, turns_since_extraction)
+       VALUES ($topicKey, 0, 1)
+       ON CONFLICT(topic_key) DO UPDATE
+       SET turns_since_extraction = turns_since_extraction + 1`,
+    )
+    .run({ $topicKey: topicKey });
+}
+
+/**
+ * Advance the extraction cursor after a successful extraction run.
+ * Resets turns_since_extraction to 0.
+ *
+ * Uses MAX() as defense-in-depth — the caller (loop.ts) serializes
+ * extraction per topic, so out-of-order advances should not occur,
+ * but the guard is cheap and makes the invariant self-enforcing.
+ */
+export function advanceExtractionCursor(
+  topicKey: string,
+  lastRowid: number,
+): void {
+  const database = getDatabase();
+  database
+    .prepare(
+      `INSERT INTO extraction_cursors (topic_key, last_extracted_rowid, turns_since_extraction)
+       VALUES ($topicKey, $lastRowid, 0)
+       ON CONFLICT(topic_key) DO UPDATE
+       SET last_extracted_rowid = MAX(last_extracted_rowid, $lastRowid),
+           turns_since_extraction = 0`,
+    )
+    .run({ $topicKey: topicKey, $lastRowid: lastRowid });
+}
+
+/**
+ * Load turns newer than the extraction cursor for a topic.
+ *
+ * Returns turns with _rowid_ > afterRowid, ordered oldest-first.
+ * Also returns each turn's _rowid_ for cursor advancement.
+ *
+ * @param limit Maximum number of turns to return (default: no limit).
+ */
+export function loadTurnsSinceCursor(
+  topicKey: string,
+  afterRowid: number,
+  limit?: number,
+): Array<Turn & { rowid: number }> {
+  const database = getDatabase();
+  const limitClause = limit !== undefined ? `LIMIT $limit` : "";
+  return database
+    .prepare(
+      `SELECT _rowid_ AS rowid, id, topic_key, role, content, created_at
+       FROM turns
+       WHERE topic_key = $topicKey AND _rowid_ > $afterRowid
+       ORDER BY _rowid_ ASC
+       ${limitClause}`,
+    )
+    .all(
+      limit !== undefined
+        ? { $topicKey: topicKey, $afterRowid: afterRowid, $limit: limit }
+        : { $topicKey: topicKey, $afterRowid: afterRowid },
+    ) as Array<Turn & { rowid: number }>;
 }

--- a/src/extraction.ts
+++ b/src/extraction.ts
@@ -1,0 +1,374 @@
+/**
+ * Fact extraction pipeline for Cortex.
+ *
+ * Extracts durable facts, preferences, and decisions from conversation turns
+ * and stores them in Engram. Runs asynchronously (non-blocking) every N turns
+ * per topic, using a cheap/fast model specified by extractionModel in config.
+ *
+ * Design:
+ * - Conditional on extractionModel being set (no-op if absent)
+ * - Serialized per topic by the caller (loop.ts in-flight guard) — no
+ *   concurrent extraction runs for the same topic, eliminating cursor races
+ * - Uses extraction cursors in SQLite to track progress per topic
+ * - Passes existing Engram memories into the extraction prompt for dedup
+ * - Uses upsert with deterministic idempotency keys (re-extraction safe)
+ * - Caps at MAX_FACTS_PER_RUN to guard against hallucinating models
+ * - Never blocks the response path — caller wraps in fire-and-forget
+ */
+
+import type { Result } from "@shetty4l/core/result";
+import { err, ok } from "@shetty4l/core/result";
+import type { CortexConfig } from "./config";
+import {
+  advanceExtractionCursor,
+  getExtractionCursor,
+  loadTurnsSinceCursor,
+} from "./db";
+import { recall, remember } from "./engram";
+import type { ChatMessage } from "./synapse";
+import { chat } from "./synapse";
+
+// --- Constants ---
+
+/** Maximum facts stored per extraction run. */
+const MAX_FACTS_PER_RUN = 10;
+
+/** Maximum existing memories to include in the extraction prompt for dedup. */
+const DEDUP_CONTEXT_LIMIT = 10;
+
+/** Maximum turns to feed into a single extraction prompt. */
+const MAX_TURNS_PER_EXTRACTION = 100;
+
+/**
+ * Approximate character budget for turns in a single extraction prompt.
+ * Prevents context-window overflow when turns contain long content
+ * (e.g. code dumps, logs). At ~4 chars/token this is roughly 12.5k tokens,
+ * well within the context limits of cheap extraction models.
+ *
+ * The drain loop naturally handles the remainder — if a batch is trimmed,
+ * subsequent iterations pick up where we left off.
+ */
+const MAX_EXTRACTION_CHARS = 50_000;
+
+/** Valid categories for extracted facts. */
+const VALID_CATEGORIES = new Set(["fact", "preference", "decision"]);
+
+// --- Types ---
+
+interface ExtractedFact {
+  content: string;
+  category: string;
+}
+
+// --- Extraction ---
+
+/**
+ * Run extraction for a topic if due.
+ *
+ * Called after saving a turn pair. The caller (loop.ts) is responsible for
+ * incrementing the turn counter BEFORE calling this function, so that the
+ * counter stays accurate even when this call is skipped by the in-flight guard.
+ *
+ * Safe to call as fire-and-forget — all errors are caught and logged.
+ */
+export async function maybeExtract(
+  topicKey: string,
+  config: CortexConfig,
+): Promise<void> {
+  // Guard: extraction disabled if no model configured
+  if (!config.extractionModel) return;
+
+  // Check if extraction is due
+  const cursor = getExtractionCursor(topicKey);
+  if (!cursor || cursor.turns_since_extraction < config.extractionInterval) {
+    return;
+  }
+
+  let afterRowid = cursor.last_extracted_rowid;
+
+  // Loop to drain the backlog — each iteration processes up to
+  // MAX_TURNS_PER_EXTRACTION turns, trimmed to fit within
+  // MAX_EXTRACTION_CHARS. This ensures that a large backlog
+  // (e.g. after downtime) is fully processed rather than orphaned,
+  // and that oversized batches don't permanently block extraction.
+  while (true) {
+    const loaded = loadTurnsSinceCursor(
+      topicKey,
+      afterRowid,
+      MAX_TURNS_PER_EXTRACTION,
+    );
+    if (loaded.length === 0) {
+      // No more turns — advance cursor to reset counter
+      advanceExtractionCursor(topicKey, afterRowid);
+      break;
+    }
+
+    // Trim to character budget so the prompt fits the extraction model's
+    // context window. The drain loop handles the remainder naturally.
+    const turns = trimToBudget(loaded);
+
+    const success = await extractBatch(topicKey, turns, config);
+    if (!success) {
+      // Model or parse failure — stop draining, don't advance cursor.
+      // Turns will be re-processed next time.
+      break;
+    }
+
+    const lastRowid = turns[turns.length - 1].rowid;
+    advanceExtractionCursor(topicKey, lastRowid);
+    afterRowid = lastRowid;
+
+    // Continue draining if the batch was trimmed (more turns remain at
+    // the same cursor position) or if the DB returned a full page
+    // (there may be more turns beyond this page). Break only when
+    // we processed everything loaded AND the page wasn't full.
+    if (
+      turns.length === loaded.length &&
+      loaded.length < MAX_TURNS_PER_EXTRACTION
+    )
+      break;
+  }
+}
+
+/**
+ * Extract facts from a single batch of turns.
+ *
+ * Returns true if extraction succeeded (even if no facts found).
+ * Returns false on model call or parse failure (caller should stop draining).
+ */
+async function extractBatch(
+  topicKey: string,
+  turns: Array<{ role: string; content: string; rowid: number }>,
+  config: CortexConfig,
+): Promise<boolean> {
+  // Recall existing memories for dedup context (graceful on failure)
+  const topicSummary = turns
+    .filter((t) => t.role === "user")
+    .map((t) => t.content)
+    .slice(0, 3)
+    .join(" ");
+  const recallResult = await recall(topicSummary, config.engramUrl, {
+    limit: DEDUP_CONTEXT_LIMIT,
+    scopeId: topicKey,
+  });
+  const existingMemories = recallResult.ok ? recallResult.value : [];
+
+  // Build extraction prompt
+  const messages = buildExtractionPrompt(turns, existingMemories);
+
+  // Call extraction model (extractionModel is guaranteed set by caller guard)
+  const result = await chat(
+    messages,
+    config.extractionModel!,
+    config.synapseUrl,
+  );
+  if (!result.ok) {
+    console.error(
+      `cortex: [${topicKey}] extraction model failed: ${result.error}`,
+    );
+    return false;
+  }
+
+  // Parse extracted facts
+  const parseResult = parseExtractionResponse(result.value.content);
+  if (!parseResult.ok) {
+    console.error(`cortex: [${topicKey}] ${parseResult.error}`);
+    return false;
+  }
+  const facts = parseResult.value;
+
+  // Store facts in Engram (continue on individual failures)
+  let stored = 0;
+  for (const fact of facts) {
+    const key = await computeIdempotencyKey(
+      topicKey,
+      fact.content,
+      fact.category,
+    );
+    const rememberResult = await remember(
+      {
+        content: fact.content,
+        category: fact.category,
+        scopeId: topicKey,
+        idempotencyKey: key,
+        upsert: true,
+      },
+      config.engramUrl,
+    );
+
+    if (rememberResult.ok && rememberResult.value !== null) {
+      stored++;
+    } else if (!rememberResult.ok) {
+      console.error(
+        `cortex: [${topicKey}] remember failed: ${rememberResult.error}`,
+      );
+    }
+  }
+
+  if (facts.length > 0) {
+    console.error(
+      `cortex: [${topicKey}] extracted ${stored}/${facts.length} facts from ${turns.length} turns`,
+    );
+  }
+
+  return true;
+}
+
+// --- Prompt construction ---
+
+function buildExtractionPrompt(
+  turns: Array<{ role: string; content: string }>,
+  existingMemories: Array<{ content: string; category: string | null }>,
+): ChatMessage[] {
+  let systemContent =
+    "You extract durable facts, preferences, and decisions from conversation turns.\n" +
+    "Respond with ONLY a JSON array — no markdown, no explanation, no surrounding text.\n" +
+    'Format: [{ "content": "...", "category": "fact" | "preference" | "decision" }]\n' +
+    "Respond with [] if nothing new to extract. Do NOT repeat facts already known.\n" +
+    "Only extract concrete, specific information. Skip pleasantries and filler.\n" +
+    "Each fact should be a single, self-contained statement.";
+
+  if (existingMemories.length > 0) {
+    systemContent += "\n\nKnown memories (do NOT repeat these):";
+    for (const mem of existingMemories) {
+      const cat = mem.category ? ` [${mem.category}]` : "";
+      systemContent += `\n- ${mem.content}${cat}`;
+    }
+  }
+
+  let userContent = "New conversation turns:\n";
+  for (const turn of turns) {
+    userContent += `${turn.role}: ${turn.content}\n`;
+  }
+
+  return [
+    { role: "system", content: systemContent },
+    { role: "user", content: userContent },
+  ];
+}
+
+// --- Response parsing ---
+
+/**
+ * Parse the extraction model's response into structured facts.
+ *
+ * Returns Err on parse failure (caller should not advance cursor).
+ * Returns Ok with empty array on valid empty response (no facts to extract).
+ * Caps at MAX_FACTS_PER_RUN.
+ */
+function parseExtractionResponse(response: string): Result<ExtractedFact[]> {
+  // Two-stage parse:
+  // 1. JSON.parse directly — the prompt explicitly requests raw JSON output,
+  //    so this handles the vast majority of cases.
+  // 2. Code fence fallback — some models wrap output in ```json ... ```
+  //    despite being told not to. Extract the fenced content and parse it.
+  //
+  // No regex-based bracket matching — that approach is inherently fragile
+  // with free-form LLM output. If neither stage works, the model isn't
+  // following format instructions and the extractionModel config should
+  // point at a more capable model.
+  let parsed: unknown;
+
+  // Stage 1: Direct parse
+  try {
+    parsed = JSON.parse(response);
+  } catch {
+    // Stage 2: Code fence extraction
+    const fenceMatch = response.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+    if (fenceMatch) {
+      try {
+        parsed = JSON.parse(fenceMatch[1]);
+      } catch {
+        return err("extraction response has invalid JSON in code fence");
+      }
+    } else {
+      return err("extraction response is not valid JSON");
+    }
+  }
+
+  if (!Array.isArray(parsed)) {
+    return err("extraction response is not an array");
+  }
+
+  // Validate and filter each fact
+  const facts: ExtractedFact[] = [];
+  for (const item of parsed) {
+    if (
+      typeof item !== "object" ||
+      item === null ||
+      typeof item.content !== "string" ||
+      typeof item.category !== "string"
+    ) {
+      continue; // Skip malformed entries
+    }
+
+    const content = item.content.trim();
+    const category = item.category.toLowerCase().trim();
+
+    // Skip empty or very short facts
+    if (content.length < 5) continue;
+
+    // Validate category
+    if (!VALID_CATEGORIES.has(category)) continue;
+
+    facts.push({ content, category });
+  }
+
+  if (facts.length > MAX_FACTS_PER_RUN) {
+    console.error(
+      `cortex: extraction returned ${parsed.length} facts, capping at ${MAX_FACTS_PER_RUN}`,
+    );
+  }
+
+  return ok(facts.slice(0, MAX_FACTS_PER_RUN));
+}
+
+// --- Batch sizing ---
+
+/**
+ * Trim a list of turns to fit within MAX_EXTRACTION_CHARS.
+ *
+ * Walks the list front-to-back, accumulating character count.
+ * Stops adding turns when the next turn would exceed the budget.
+ * Always includes at least one turn so a single long turn doesn't
+ * deadlock the drain loop (the extraction may still fail on the
+ * model side, but the batch shrinks to the minimum possible).
+ *
+ * Exported for testing.
+ */
+export function trimToBudget<T extends { content: string }>(
+  turns: T[],
+  budget: number = MAX_EXTRACTION_CHARS,
+): T[] {
+  if (turns.length === 0) return turns;
+
+  let chars = 0;
+  for (let i = 0; i < turns.length; i++) {
+    chars += turns[i].content.length;
+    if (chars > budget && i > 0) {
+      return turns.slice(0, i);
+    }
+  }
+  return turns;
+}
+
+// --- Idempotency ---
+
+/**
+ * Compute a deterministic idempotency key for an extracted fact.
+ *
+ * Uses SHA-256 of topicKey + content + category to ensure re-extraction
+ * of the same turns produces the same keys (upsert dedup).
+ */
+async function computeIdempotencyKey(
+  topicKey: string,
+  content: string,
+  category: string,
+): Promise<string> {
+  const input = `${topicKey}\0${content}\0${category}`;
+  const buffer = new TextEncoder().encode(input);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hex = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+  return `cortex:extract:${hex.slice(0, 16)}`;
+}

--- a/test/extraction.test.ts
+++ b/test/extraction.test.ts
@@ -1,0 +1,689 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import type { CortexConfig } from "../src/config";
+import {
+  advanceExtractionCursor,
+  closeDatabase,
+  getExtractionCursor,
+  incrementTurnsSinceExtraction,
+  initDatabase,
+  loadTurnsSinceCursor,
+  saveTurn,
+} from "../src/db";
+import { maybeExtract, trimToBudget } from "../src/extraction";
+
+// --- Mock Synapse server (extraction model) ---
+
+let mockSynapse: ReturnType<typeof Bun.serve>;
+let mockSynapseUrl: string;
+let mockSynapseHandler: (req: Request) => Response | Promise<Response>;
+
+beforeAll(() => {
+  mockSynapseHandler = () =>
+    Response.json({ error: "no mock configured" }, { status: 500 });
+
+  mockSynapse = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req) {
+      return mockSynapseHandler(req);
+    },
+  });
+
+  mockSynapseUrl = `http://127.0.0.1:${mockSynapse.port}`;
+});
+
+// --- Mock Engram server ---
+
+let mockEngram: ReturnType<typeof Bun.serve>;
+let mockEngramUrl: string;
+let mockEngramHandler: (req: Request) => Response | Promise<Response>;
+let engramRememberCalls: Array<Record<string, unknown>>;
+let engramRecallCalls: Array<Record<string, unknown>>;
+
+beforeAll(() => {
+  engramRememberCalls = [];
+  engramRecallCalls = [];
+
+  mockEngramHandler = async (req) => {
+    const path = new URL(req.url).pathname;
+    const body = (await req.json()) as Record<string, unknown>;
+
+    if (path === "/remember") {
+      engramRememberCalls.push(body);
+      return Response.json({
+        id: `mem_${crypto.randomUUID().slice(0, 8)}`,
+        status: "created",
+      });
+    }
+
+    if (path === "/recall") {
+      engramRecallCalls.push(body);
+      return Response.json({ memories: [], fallback_mode: false });
+    }
+
+    return Response.json({ error: "not found" }, { status: 404 });
+  };
+
+  mockEngram = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req) {
+      return mockEngramHandler(req);
+    },
+  });
+
+  mockEngramUrl = `http://127.0.0.1:${mockEngram.port}`;
+});
+
+afterAll(() => {
+  mockSynapse.stop(true);
+  mockEngram.stop(true);
+});
+
+// --- Test config ---
+
+function testConfig(overrides?: Partial<CortexConfig>): CortexConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    ingestApiKey: "test-key",
+    synapseUrl: mockSynapseUrl,
+    engramUrl: mockEngramUrl,
+    model: "test-model",
+    extractionModel: "test-extraction-model",
+    extractionInterval: 3,
+    activeWindowSize: 10,
+    turnTtlDays: 30,
+    schedulerTickSeconds: 30,
+    schedulerTimezone: "UTC",
+    outboxPollDefaultBatch: 20,
+    outboxLeaseSeconds: 60,
+    outboxMaxAttempts: 10,
+    skillDirs: [],
+    toolTimeoutMs: 20000,
+    ...overrides,
+  };
+}
+
+// --- Helpers ---
+
+function openaiResponse(content: string) {
+  return {
+    id: "chat-test",
+    object: "chat.completion",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+  };
+}
+
+function extractionResponse(
+  facts: Array<{ content: string; category: string }>,
+) {
+  return openaiResponse(JSON.stringify(facts));
+}
+
+/** Save N turn pairs (does not touch extraction cursor). */
+function seedTurns(topicKey: string, count: number): void {
+  for (let i = 0; i < count; i++) {
+    saveTurn(topicKey, "user", `User message ${i + 1}`);
+    saveTurn(topicKey, "assistant", `Assistant reply ${i + 1}`);
+  }
+}
+
+/**
+ * Simulate a processed message: increment the turn counter then run extraction.
+ * This mirrors what loop.ts does — increment is in the loop, not inside maybeExtract.
+ */
+async function processAndExtract(
+  topicKey: string,
+  config: CortexConfig,
+): Promise<void> {
+  if (config.extractionModel) {
+    incrementTurnsSinceExtraction(topicKey);
+  }
+  await maybeExtract(topicKey, config);
+}
+
+// --- Tests ---
+
+describe("extraction cursors (DB)", () => {
+  beforeEach(() => {
+    initDatabase(":memory:");
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test("getExtractionCursor returns null for unknown topic", () => {
+    const cursor = getExtractionCursor("unknown-topic");
+    expect(cursor).toBeNull();
+  });
+
+  test("incrementTurnsSinceExtraction creates cursor on first call", () => {
+    incrementTurnsSinceExtraction("topic-1");
+    const cursor = getExtractionCursor("topic-1");
+
+    expect(cursor).not.toBeNull();
+    expect(cursor!.last_extracted_rowid).toBe(0);
+    expect(cursor!.turns_since_extraction).toBe(1);
+  });
+
+  test("incrementTurnsSinceExtraction increments on subsequent calls", () => {
+    incrementTurnsSinceExtraction("topic-1");
+    incrementTurnsSinceExtraction("topic-1");
+    incrementTurnsSinceExtraction("topic-1");
+
+    const cursor = getExtractionCursor("topic-1");
+    expect(cursor!.turns_since_extraction).toBe(3);
+  });
+
+  test("advanceExtractionCursor resets counter", () => {
+    incrementTurnsSinceExtraction("topic-1");
+    incrementTurnsSinceExtraction("topic-1");
+    incrementTurnsSinceExtraction("topic-1");
+
+    advanceExtractionCursor("topic-1", 42);
+
+    const cursor = getExtractionCursor("topic-1");
+    expect(cursor!.last_extracted_rowid).toBe(42);
+    expect(cursor!.turns_since_extraction).toBe(0);
+  });
+
+  test("loadTurnsSinceCursor returns turns after rowid", () => {
+    saveTurn("topic-1", "user", "Old message");
+    saveTurn("topic-1", "assistant", "Old reply");
+
+    // Get the rowid of the last old turn
+    const oldTurns = loadTurnsSinceCursor("topic-1", 0);
+    const lastOldRowid = oldTurns[oldTurns.length - 1].rowid;
+
+    saveTurn("topic-1", "user", "New message");
+    saveTurn("topic-1", "assistant", "New reply");
+
+    const newTurns = loadTurnsSinceCursor("topic-1", lastOldRowid);
+    expect(newTurns).toHaveLength(2);
+    expect(newTurns[0].content).toBe("New message");
+    expect(newTurns[1].content).toBe("New reply");
+  });
+
+  test("loadTurnsSinceCursor returns empty when no turns after cursor", () => {
+    saveTurn("topic-1", "user", "A message");
+    const turns = loadTurnsSinceCursor("topic-1", 0);
+    const lastRowid = turns[turns.length - 1].rowid;
+
+    const newTurns = loadTurnsSinceCursor("topic-1", lastRowid);
+    expect(newTurns).toHaveLength(0);
+  });
+
+  test("loadTurnsSinceCursor isolates by topic", () => {
+    saveTurn("topic-a", "user", "Topic A message");
+    saveTurn("topic-b", "user", "Topic B message");
+
+    const turnsA = loadTurnsSinceCursor("topic-a", 0);
+    expect(turnsA).toHaveLength(1);
+    expect(turnsA[0].content).toBe("Topic A message");
+  });
+});
+
+describe("maybeExtract", () => {
+  beforeEach(() => {
+    initDatabase(":memory:");
+    engramRememberCalls = [];
+    engramRecallCalls = [];
+    // Default: return empty extraction
+    mockSynapseHandler = () => Response.json(extractionResponse([]));
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test("skipped when extractionModel is undefined", async () => {
+    const config = testConfig({ extractionModel: undefined });
+    seedTurns("topic-1", 5);
+
+    await maybeExtract("topic-1", config);
+
+    // No cursor created, no model call
+    expect(getExtractionCursor("topic-1")).toBeNull();
+    expect(engramRememberCalls).toHaveLength(0);
+  });
+
+  test("skipped when turns < extractionInterval", async () => {
+    const config = testConfig({ extractionInterval: 3 });
+    seedTurns("topic-1", 1);
+
+    // Simulate 1 turn processed (loop increments counter, then calls maybeExtract)
+    await processAndExtract("topic-1", config);
+
+    const cursor = getExtractionCursor("topic-1");
+    expect(cursor!.turns_since_extraction).toBe(1);
+    expect(engramRememberCalls).toHaveLength(0);
+  });
+
+  test("triggers at exactly extractionInterval turns", async () => {
+    const config = testConfig({ extractionInterval: 3 });
+    seedTurns("topic-1", 3);
+
+    mockSynapseHandler = () =>
+      Response.json(
+        extractionResponse([
+          { content: "User likes TypeScript", category: "preference" },
+        ]),
+      );
+
+    // Simulate 3 turns processed
+    await processAndExtract("topic-1", config);
+    await processAndExtract("topic-1", config);
+    await processAndExtract("topic-1", config);
+
+    // Should have triggered extraction on the 3rd call
+    expect(engramRememberCalls).toHaveLength(1);
+    expect(engramRememberCalls[0].content).toBe("User likes TypeScript");
+  });
+
+  test("stores facts with correct category, scope, and upsert", async () => {
+    const config = testConfig({ extractionInterval: 1 });
+    seedTurns("my-topic", 1);
+
+    mockSynapseHandler = () =>
+      Response.json(
+        extractionResponse([
+          { content: "User lives in Seattle", category: "fact" },
+          { content: "User prefers dark mode", category: "preference" },
+        ]),
+      );
+
+    await processAndExtract("my-topic", config);
+
+    expect(engramRememberCalls).toHaveLength(2);
+
+    // First fact
+    expect(engramRememberCalls[0].content).toBe("User lives in Seattle");
+    expect(engramRememberCalls[0].category).toBe("fact");
+    expect(engramRememberCalls[0].scope_id).toBe("my-topic");
+    expect(engramRememberCalls[0].upsert).toBe(true);
+    expect(engramRememberCalls[0].idempotency_key).toMatch(
+      /^cortex:extract:[a-f0-9]{16}$/,
+    );
+
+    // Second fact
+    expect(engramRememberCalls[1].content).toBe("User prefers dark mode");
+    expect(engramRememberCalls[1].category).toBe("preference");
+  });
+
+  test("idempotency keys are deterministic", async () => {
+    const config = testConfig({ extractionInterval: 1 });
+    seedTurns("topic-1", 1);
+
+    mockSynapseHandler = () =>
+      Response.json(
+        extractionResponse([
+          { content: "User likes coffee", category: "preference" },
+        ]),
+      );
+
+    await processAndExtract("topic-1", config);
+    const firstKey = engramRememberCalls[0].idempotency_key;
+
+    // Reset cursor to force re-extraction of same turns
+    engramRememberCalls = [];
+    advanceExtractionCursor("topic-1", 0);
+
+    // Add another turn to trigger extraction again
+    seedTurns("topic-1", 1);
+    await processAndExtract("topic-1", config);
+
+    // Same content + topic + category should produce same key
+    const secondKey = engramRememberCalls[0].idempotency_key;
+    expect(secondKey).toBe(firstKey);
+  });
+
+  test("cursor advances after successful extraction", async () => {
+    const config = testConfig({ extractionInterval: 1 });
+    seedTurns("topic-1", 2);
+
+    mockSynapseHandler = () =>
+      Response.json(
+        extractionResponse([{ content: "Some fact", category: "fact" }]),
+      );
+
+    await processAndExtract("topic-1", config);
+
+    const cursor = getExtractionCursor("topic-1");
+    expect(cursor!.turns_since_extraction).toBe(0);
+    expect(cursor!.last_extracted_rowid).toBeGreaterThan(0);
+  });
+
+  test("cursor does NOT advance on model call failure", async () => {
+    const config = testConfig({ extractionInterval: 1 });
+    seedTurns("topic-1", 1);
+
+    mockSynapseHandler = () =>
+      Response.json(
+        { error: { message: "boom", type: "server_error" } },
+        { status: 500 },
+      );
+
+    await processAndExtract("topic-1", config);
+
+    const cursor = getExtractionCursor("topic-1");
+    // Counter was incremented but cursor NOT advanced
+    expect(cursor!.turns_since_extraction).toBe(1);
+    expect(cursor!.last_extracted_rowid).toBe(0);
+  });
+
+  test("cursor does NOT advance on malformed JSON response", async () => {
+    const config = testConfig({ extractionInterval: 1 });
+    seedTurns("topic-1", 1);
+
+    mockSynapseHandler = () =>
+      Response.json(
+        openaiResponse("Here are some thoughts about the conversation..."),
+      );
+
+    await processAndExtract("topic-1", config);
+
+    const cursor = getExtractionCursor("topic-1");
+    expect(cursor!.turns_since_extraction).toBe(1);
+    expect(cursor!.last_extracted_rowid).toBe(0);
+  });
+
+  test("cursor advances even if all remember calls fail", async () => {
+    const config = testConfig({ extractionInterval: 1 });
+    seedTurns("topic-1", 1);
+
+    mockSynapseHandler = () =>
+      Response.json(
+        extractionResponse([{ content: "A fact", category: "fact" }]),
+      );
+
+    // Make Engram remember fail
+    const originalHandler = mockEngramHandler;
+    mockEngramHandler = async (req) => {
+      const path = new URL(req.url).pathname;
+      if (path === "/remember") {
+        return Response.json({ error: "boom" }, { status: 500 });
+      }
+      return originalHandler(req);
+    };
+
+    await processAndExtract("topic-1", config);
+
+    const cursor = getExtractionCursor("topic-1");
+    // Cursor advanced despite remember failure (upsert makes re-extraction safe)
+    expect(cursor!.turns_since_extraction).toBe(0);
+    expect(cursor!.last_extracted_rowid).toBeGreaterThan(0);
+  });
+
+  test("empty extraction result advances cursor", async () => {
+    const config = testConfig({ extractionInterval: 1 });
+    seedTurns("topic-1", 1);
+
+    mockSynapseHandler = () => Response.json(extractionResponse([]));
+
+    await processAndExtract("topic-1", config);
+
+    const cursor = getExtractionCursor("topic-1");
+    expect(cursor!.turns_since_extraction).toBe(0);
+    expect(cursor!.last_extracted_rowid).toBeGreaterThan(0);
+    expect(engramRememberCalls).toHaveLength(0);
+  });
+
+  test("existing memories passed into extraction prompt for dedup", async () => {
+    const config = testConfig({ extractionInterval: 1 });
+    seedTurns("topic-1", 1);
+
+    let capturedSynapseBody: {
+      messages?: Array<{ role: string; content: string }>;
+    } = {};
+
+    // Return existing memories from Engram recall
+    mockEngramHandler = async (req) => {
+      const path = new URL(req.url).pathname;
+      const body = (await req.json()) as Record<string, unknown>;
+
+      if (path === "/recall") {
+        engramRecallCalls.push(body);
+        return Response.json({
+          memories: [
+            {
+              id: "m1",
+              content: "User lives in Seattle",
+              category: "fact",
+              strength: 1,
+              relevance: 0.9,
+            },
+          ],
+          fallback_mode: false,
+        });
+      }
+
+      if (path === "/remember") {
+        engramRememberCalls.push(body);
+        return Response.json({ id: "mem-1", status: "created" });
+      }
+
+      return Response.json({ error: "not found" }, { status: 404 });
+    };
+
+    mockSynapseHandler = async (req) => {
+      capturedSynapseBody = (await req.json()) as typeof capturedSynapseBody;
+      return Response.json(extractionResponse([]));
+    };
+
+    await processAndExtract("topic-1", config);
+
+    // System prompt should contain existing memory for dedup
+    const systemMsg = capturedSynapseBody.messages?.[0];
+    expect(systemMsg).toBeDefined();
+    expect(systemMsg!.content).toContain("User lives in Seattle");
+    expect(systemMsg!.content).toContain("do NOT repeat");
+  });
+
+  test("multiple extraction cycles work correctly", async () => {
+    const config = testConfig({ extractionInterval: 1 });
+
+    // Cycle 1
+    seedTurns("topic-1", 1);
+    mockSynapseHandler = () =>
+      Response.json(
+        extractionResponse([
+          { content: "Fact from cycle 1", category: "fact" },
+        ]),
+      );
+
+    await processAndExtract("topic-1", config);
+    expect(engramRememberCalls).toHaveLength(1);
+    expect(engramRememberCalls[0].content).toBe("Fact from cycle 1");
+
+    const cursor1 = getExtractionCursor("topic-1");
+    expect(cursor1!.turns_since_extraction).toBe(0);
+
+    // Cycle 2 — more turns
+    engramRememberCalls = [];
+    seedTurns("topic-1", 1);
+    mockSynapseHandler = () =>
+      Response.json(
+        extractionResponse([
+          { content: "Fact from cycle 2", category: "decision" },
+        ]),
+      );
+
+    await processAndExtract("topic-1", config);
+    expect(engramRememberCalls).toHaveLength(1);
+    expect(engramRememberCalls[0].content).toBe("Fact from cycle 2");
+
+    const cursor2 = getExtractionCursor("topic-1");
+    expect(cursor2!.last_extracted_rowid).toBeGreaterThan(
+      cursor1!.last_extracted_rowid,
+    );
+  });
+
+  test("caps facts at MAX_FACTS_PER_RUN (10)", async () => {
+    const config = testConfig({ extractionInterval: 1 });
+    seedTurns("topic-1", 1);
+
+    // Return 15 facts (exceeds cap)
+    const manyFacts = Array.from({ length: 15 }, (_, i) => ({
+      content: `Fact number ${i + 1} extracted`,
+      category: "fact",
+    }));
+
+    mockSynapseHandler = () => Response.json(extractionResponse(manyFacts));
+
+    await processAndExtract("topic-1", config);
+
+    // Should cap at 10
+    expect(engramRememberCalls).toHaveLength(10);
+  });
+
+  test("filters out invalid categories", async () => {
+    const config = testConfig({ extractionInterval: 1 });
+    seedTurns("topic-1", 1);
+
+    mockSynapseHandler = () =>
+      Response.json(
+        extractionResponse([
+          { content: "Valid fact", category: "fact" },
+          { content: "Invalid category", category: "opinion" },
+          { content: "Valid preference", category: "preference" },
+        ]),
+      );
+
+    await processAndExtract("topic-1", config);
+
+    // Only valid categories stored
+    expect(engramRememberCalls).toHaveLength(2);
+    expect(engramRememberCalls[0].content).toBe("Valid fact");
+    expect(engramRememberCalls[1].content).toBe("Valid preference");
+  });
+
+  test("handles markdown-wrapped JSON in model response", async () => {
+    const config = testConfig({ extractionInterval: 1 });
+    seedTurns("topic-1", 1);
+
+    const wrappedResponse =
+      "Here are the extracted facts:\n```json\n" +
+      JSON.stringify([{ content: "User is a developer", category: "fact" }]) +
+      "\n```";
+
+    mockSynapseHandler = () => Response.json(openaiResponse(wrappedResponse));
+
+    await processAndExtract("topic-1", config);
+
+    expect(engramRememberCalls).toHaveLength(1);
+    expect(engramRememberCalls[0].content).toBe("User is a developer");
+  });
+});
+
+describe("trimToBudget", () => {
+  test("returns all turns when within budget", () => {
+    const turns = [
+      { content: "short", rowid: 1 },
+      { content: "also short", rowid: 2 },
+    ];
+    const result = trimToBudget(turns, 1000);
+    expect(result).toHaveLength(2);
+  });
+
+  test("trims turns that exceed budget", () => {
+    const turns = [
+      { content: "a".repeat(100), rowid: 1 },
+      { content: "b".repeat(100), rowid: 2 },
+      { content: "c".repeat(100), rowid: 3 },
+    ];
+    // Budget of 150 fits turn 1 (100 chars) but overflows on turn 2 (200 total)
+    const result = trimToBudget(turns, 150);
+    expect(result).toHaveLength(1);
+    expect(result[0].rowid).toBe(1);
+  });
+
+  test("always includes at least one turn even if it exceeds budget", () => {
+    const turns = [
+      { content: "x".repeat(10_000), rowid: 1 },
+      { content: "short", rowid: 2 },
+    ];
+    const result = trimToBudget(turns, 100);
+    expect(result).toHaveLength(1);
+    expect(result[0].rowid).toBe(1);
+  });
+
+  test("returns empty array for empty input", () => {
+    const result = trimToBudget([], 1000);
+    expect(result).toHaveLength(0);
+  });
+
+  test("trims at exact budget boundary", () => {
+    const turns = [
+      { content: "a".repeat(50), rowid: 1 },
+      { content: "b".repeat(50), rowid: 2 },
+      { content: "c".repeat(1), rowid: 3 },
+    ];
+    // Budget of 100: turn 1 (50) + turn 2 (100) = exactly at boundary
+    // turn 3 would push to 101 > 100, so it's excluded
+    const result = trimToBudget(turns, 100);
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe("maybeExtract with oversized batches", () => {
+  beforeEach(() => {
+    initDatabase(":memory:");
+    engramRememberCalls = [];
+    engramRecallCalls = [];
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test("splits oversized backlog across multiple drain iterations", async () => {
+    const config = testConfig({ extractionInterval: 1 });
+    let extractionCalls = 0;
+
+    // Seed many turns with large content to exceed MAX_EXTRACTION_CHARS (50k)
+    // Each turn pair is ~6k chars, so 10 pairs = ~60k chars (exceeds 50k budget)
+    for (let i = 0; i < 10; i++) {
+      saveTurn("topic-1", "user", `Message ${i + 1}: ${"x".repeat(3000)}`);
+      saveTurn("topic-1", "assistant", `Reply ${i + 1}: ${"y".repeat(3000)}`);
+    }
+
+    mockSynapseHandler = () => {
+      extractionCalls++;
+      return Response.json(extractionResponse([]));
+    };
+
+    await processAndExtract("topic-1", config);
+
+    // Should have required multiple extraction model calls (batches)
+    // because the total content exceeds the character budget
+    expect(extractionCalls).toBeGreaterThanOrEqual(2);
+
+    // Cursor should be fully advanced (all turns processed)
+    const cursor = getExtractionCursor("topic-1");
+    expect(cursor!.turns_since_extraction).toBe(0);
+
+    // Verify all turns are behind the cursor
+    const remaining = loadTurnsSinceCursor(
+      "topic-1",
+      cursor!.last_extracted_rowid,
+    );
+    expect(remaining).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Add async fact extraction pipeline that runs every N processed messages per topic
- Extract durable facts, preferences, and decisions from conversation turns via a cheap extraction model
- Store extracted facts in Engram with upsert and deterministic idempotency keys

## Changes

### New files
- `src/extraction.ts` — extraction pipeline: cursor tracking, prompt assembly, two-stage JSON parse, character budget trimming, Engram remember with upsert
- `test/extraction.test.ts` — 28 tests covering cursors, pipeline, caps, error paths, multi-cycle extraction, budget trimming, oversized batches

### Modified files
- `src/db.ts` — `extraction_cursors` table + 4 cursor helpers (`get`, `increment`, `advance`, `loadSince`)
- `src/engram.ts` — `remember()` function with graceful degradation (3s timeout, no-throw)
- `src/loop.ts` — per-topic in-flight guard, turn counter increment (always, even during in-flight extraction), fire-and-forget `maybeExtract()` call, startup log when disabled
- `test/engram.test.ts` — 6 tests for `remember()`
- `test/loop.test.ts` — 4 integration tests: extraction triggering, extraction failure resilience, in-flight counter accuracy, skipped-turn recovery

## Design decisions

- **Conditional on `extractionModel`** — if not set in config, extraction is a no-op (zero behavioral change)
- **Serialized per topic** — `extractionInFlight` Map in loop.ts ensures at most one extraction run per topic at any time. Eliminates cursor race conditions from overlapping fire-and-forget runs, prevents duplicate model/Engram calls. Subsequent triggers for an already-running topic are silently skipped; the next message re-evaluates the cursor.
- **Turn counter always increments** — `incrementTurnsSinceExtraction` is called in loop.ts *before* the in-flight guard, ensuring every processed message is counted regardless of whether extraction is currently running. This prevents extraction cadence drift when messages arrive during slow extraction runs.
- **Character budget trimming** — `trimToBudget()` caps each extraction batch at 50k characters (~12.5k tokens) to prevent context-window overflow. The drain loop naturally handles the remainder across multiple iterations. Always includes at least 1 turn to prevent deadlock. This prevents the permanent extraction blockage described in #31.
- **Cursor uses `_rowid_`** — avoids TEXT UUID vs INTEGER mismatch, consistent with existing turn ordering
- **Upsert with deterministic keys** — `cortex:extract:<sha256(topic+content+category)[:16]>` prevents duplicates on re-extraction, aligns with Engram v0.2.14 guidance
- **Cursor advances on remember failure** — upsert makes re-extraction safe; avoids infinite retry loops when Engram is down
- **10-fact cap per run** — guards against hallucinating cheap models
- **100-turn row cap per DB fetch** — prevents unbounded DB reads; backlog drain loop processes all pages
- **Two-stage JSON parse** — direct `JSON.parse` first, then code fence fallback for models that wrap in ```json. No regex bracket matching — inherently fragile with free-form LLM output.
- **`parseExtractionResponse` returns `Result`** — consistent with codebase conventions (`recall`, `remember`, `chat` all return `Result`)
- **Fire-and-forget** — extraction never blocks response delivery
- **`MAX()` on cursor advance** — defense-in-depth guard against backward cursor movement (shouldn't occur with serialization, but the check is cheap)

## Test coverage

38 new tests (176 total, all passing). Covers: disabled extraction, interval threshold, cursor advancement/non-advancement on various failure modes, fact validation, category whitelist, idempotency key determinism, MAX_FACTS cap, markdown-wrapped JSON, multi-cycle extraction, dedup context passing, loop integration, in-flight counter accuracy, skipped-turn recovery, character budget trimming (5 unit tests), and oversized batch splitting.

Closes #18
Closes #31