### PR TITLE
Add Telegram adapter with ingestion/delivery loops and runtime wiring

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,53 +9,157 @@ import { ok } from "@shetty4l/core/result";
 import { onShutdown } from "@shetty4l/core/signals";
 import { readVersion } from "@shetty4l/core/version";
 import { join } from "path";
+import type { CortexConfig } from "./config";
 import { loadConfig } from "./config";
 import { initDatabase } from "./db";
 import { startProcessingLoop } from "./loop";
 import { startServer } from "./server";
-import { createEmptyRegistry, loadSkills } from "./skills";
+import { createEmptyRegistry, loadSkills, type SkillRegistry } from "./skills";
+import {
+  startTelegramDeliveryLoop,
+  startTelegramIngestionLoop,
+  type TelegramDeliveryLoop,
+  type TelegramIngestionLoop,
+} from "./telegram";
 
 const VERSION = readVersion(join(import.meta.dir, ".."));
-console.error(`cortex v${VERSION}`);
 
-const configResult = loadConfig();
-if (!configResult.ok) {
-  console.error(`cortex: ${configResult.error}`);
-  process.exit(1);
-}
-const config = configResult.value;
-
-const dbResult = initDatabase();
-if (!dbResult.ok) {
-  console.error(`cortex: ${dbResult.error}`);
-  process.exit(1);
+interface RuntimeDeps {
+  startServer: typeof startServer;
+  startProcessingLoop: typeof startProcessingLoop;
+  startTelegramIngestionLoop: typeof startTelegramIngestionLoop;
+  startTelegramDeliveryLoop: typeof startTelegramDeliveryLoop;
+  log: (message: string) => void;
 }
 
-// Load skills from configured directories (empty registry if none configured)
-const registryResult =
-  config.skillDirs.length > 0
-    ? await loadSkills(config.skillDirs, config.skillConfig)
-    : ok(createEmptyRegistry());
+const DEFAULT_RUNTIME_DEPS: RuntimeDeps = {
+  startServer,
+  startProcessingLoop,
+  startTelegramIngestionLoop,
+  startTelegramDeliveryLoop,
+  log: console.error,
+};
 
-if (!registryResult.ok) {
-  console.error(`cortex: fatal: ${registryResult.error}`);
-  process.exit(1);
+export interface CortexRuntime {
+  stop(): Promise<void>;
 }
 
-const _registry = registryResult.value;
-console.error(
-  `cortex: loaded ${_registry.tools.length} tools from ${config.skillDirs.length} skill dirs`,
-);
+export async function startCortexRuntime(
+  config: CortexConfig,
+  registry: SkillRegistry,
+  deps: RuntimeDeps = DEFAULT_RUNTIME_DEPS,
+): Promise<CortexRuntime> {
+  const server = deps.startServer(config);
+  deps.log(`cortex: listening on http://${config.host}:${config.port}`);
 
-const server = startServer(config);
-console.error(`cortex: listening on http://${config.host}:${config.port}`);
-const loop = startProcessingLoop(config, _registry);
-console.error("cortex: processing loop started");
+  const loop = deps.startProcessingLoop(config, registry);
+  deps.log("cortex: processing loop started");
 
-onShutdown(
-  async () => {
-    await loop.stop();
-    server.stop();
-  },
-  { name: "cortex", timeoutMs: 35_000 },
-);
+  let telegramIngestion: TelegramIngestionLoop | null = null;
+  let telegramDelivery: TelegramDeliveryLoop | null = null;
+
+  if (config.telegramBotToken) {
+    try {
+      telegramIngestion = deps.startTelegramIngestionLoop(config);
+      telegramDelivery = deps.startTelegramDeliveryLoop(config);
+      deps.log("cortex: telegram adapter enabled (ingestion+delivery started)");
+    } catch (startupError) {
+      const cleanupErrors: unknown[] = [];
+
+      if (telegramDelivery) {
+        try {
+          await telegramDelivery.stop();
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
+      }
+
+      if (telegramIngestion) {
+        try {
+          await telegramIngestion.stop();
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
+      }
+
+      try {
+        await loop.stop();
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+
+      try {
+        server.stop();
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+
+      if (cleanupErrors.length > 0) {
+        deps.log(
+          `cortex: startup cleanup encountered ${cleanupErrors.length} errors`,
+        );
+      }
+
+      throw startupError;
+    }
+  } else {
+    deps.log("cortex: telegram adapter disabled (no token configured)");
+  }
+
+  return {
+    async stop() {
+      if (telegramDelivery) {
+        await telegramDelivery.stop();
+      }
+      if (telegramIngestion) {
+        await telegramIngestion.stop();
+      }
+      await loop.stop();
+      server.stop();
+    },
+  };
+}
+
+export async function run(): Promise<void> {
+  console.error(`cortex v${VERSION}`);
+
+  const configResult = loadConfig();
+  if (!configResult.ok) {
+    console.error(`cortex: ${configResult.error}`);
+    process.exit(1);
+  }
+  const config = configResult.value;
+
+  const dbResult = initDatabase();
+  if (!dbResult.ok) {
+    console.error(`cortex: ${dbResult.error}`);
+    process.exit(1);
+  }
+
+  const registryResult =
+    config.skillDirs.length > 0
+      ? await loadSkills(config.skillDirs, config.skillConfig)
+      : ok(createEmptyRegistry());
+
+  if (!registryResult.ok) {
+    console.error(`cortex: fatal: ${registryResult.error}`);
+    process.exit(1);
+  }
+
+  const registry = registryResult.value;
+  console.error(
+    `cortex: loaded ${registry.tools.length} tools from ${config.skillDirs.length} skill dirs`,
+  );
+
+  const runtime = await startCortexRuntime(config, registry);
+  onShutdown(
+    async () => {
+      await runtime.stop();
+    },
+    { name: "cortex", timeoutMs: 35_000 },
+  );
+}
+
+if (import.meta.main) {
+  await run();
+}

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -63,9 +63,13 @@ export function buildPrompt(opts: BuildPromptOpts): ChatMessage[] {
 
   messages.push({ role: "system", content: systemContent });
 
-  // 2. Turn history
+  // 2. Turn history (preserve tool_calls, tool_call_id, name for tool-calling exchanges)
   for (const turn of turns) {
-    messages.push({ role: turn.role, content: turn.content });
+    const msg: ChatMessage = { role: turn.role, content: turn.content };
+    if (turn.tool_calls) msg.tool_calls = turn.tool_calls;
+    if (turn.tool_call_id) msg.tool_call_id = turn.tool_call_id;
+    if (turn.name) msg.name = turn.name;
+    messages.push(msg);
   }
 
   // 3. Current user message

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -1,0 +1,474 @@
+import type { CortexConfig } from "./config";
+import {
+  ackOutboxMessage,
+  enqueueInboxMessage,
+  getTelegramOffset,
+  pollOutboxMessages,
+  setTelegramOffset,
+} from "./db";
+
+const TELEGRAM_API_BASE_URL = "https://api.telegram.org";
+
+type TelegramApiEnvelope<T> = {
+  ok?: boolean;
+  result?: T;
+  description?: string;
+  error_code?: number;
+};
+
+export interface TelegramMessage {
+  message_id: number;
+  date: number;
+  from?: {
+    id: number;
+  };
+  chat: {
+    id: number;
+  };
+  text?: string;
+  message_thread_id?: number;
+}
+
+export interface TelegramUpdate {
+  update_id: number;
+  message?: TelegramMessage;
+}
+
+export interface SendMessageOptions {
+  threadId?: number;
+  parseMode?: string;
+}
+
+export interface TelegramIngestionLoop {
+  stop(): Promise<void>;
+}
+
+export interface TelegramIngestionLoopOptions {
+  onErrorDelayMs?: number;
+  onEmptyDelayMs?: number;
+}
+
+export interface TelegramDeliveryLoop {
+  stop(): Promise<void>;
+}
+
+export interface TelegramDeliveryLoopOptions {
+  maxBatch?: number;
+  leaseSeconds?: number;
+  maxAttempts?: number;
+  onErrorDelayMs?: number;
+  onEmptyDelayMs?: number;
+}
+
+export class TelegramApiError extends Error {
+  readonly statusCode: number;
+  readonly method: string;
+
+  constructor(method: string, statusCode: number, message: string) {
+    super(message);
+    this.name = "TelegramApiError";
+    this.method = method;
+    this.statusCode = statusCode;
+  }
+}
+
+const TELEGRAM_MAX_MESSAGE_LENGTH = 4096;
+
+export interface TelegramTopic {
+  chatId: number;
+  threadId?: number;
+}
+
+export function parseTelegramTopicKey(topicKey: string): TelegramTopic | null {
+  const parts = topicKey.split(":");
+  if (parts.length !== 1 && parts.length !== 2) {
+    return null;
+  }
+
+  const parseInteger = (raw: string): number | null => {
+    if (!/^-?\d+$/.test(raw)) {
+      return null;
+    }
+    const value = Number(raw);
+    return Number.isSafeInteger(value) ? value : null;
+  };
+
+  const chatId = parseInteger(parts[0]);
+  if (chatId === null) {
+    return null;
+  }
+
+  if (parts.length === 1) {
+    return { chatId };
+  }
+
+  const threadId = parseInteger(parts[1]);
+  if (threadId === null) {
+    return null;
+  }
+
+  return { chatId, threadId };
+}
+
+function takeChunk(input: string, maxLength: number): string {
+  if (input.length <= maxLength) {
+    return input;
+  }
+
+  for (const boundary of ["\n\n", "\n", " "]) {
+    const maxBoundaryStart = maxLength - boundary.length;
+    if (maxBoundaryStart < 0) {
+      continue;
+    }
+
+    const splitAt = input.lastIndexOf(boundary, maxBoundaryStart);
+    if (splitAt > 0) {
+      return input.slice(0, splitAt + boundary.length);
+    }
+  }
+
+  return input.slice(0, maxLength);
+}
+
+export function splitTelegramMessageText(
+  text: string,
+  maxLength = TELEGRAM_MAX_MESSAGE_LENGTH,
+): string[] {
+  const chunkLimit =
+    Number.isFinite(maxLength) && maxLength > 0 ? Math.floor(maxLength) : 1;
+
+  if (text.length <= chunkLimit) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    let chunk = takeChunk(remaining, chunkLimit);
+    if (chunk.length === 0) {
+      chunk = remaining.slice(0, chunkLimit);
+    }
+    chunks.push(chunk);
+    remaining = remaining.slice(chunk.length);
+  }
+  return chunks;
+}
+
+function summarizeBody(body: string): string {
+  const compact = body.replace(/\s+/g, " ").trim();
+  if (compact.length === 0) return "(empty response body)";
+  return compact.slice(0, 300);
+}
+
+async function callTelegramApi<T>(
+  botToken: string,
+  method: string,
+  payload: Record<string, unknown>,
+  timeoutMs: number,
+): Promise<T> {
+  const url = `${TELEGRAM_API_BASE_URL}/bot${botToken}/${method}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (e) {
+    const isTimeout =
+      e instanceof Error &&
+      (e.name === "TimeoutError" || e.name === "AbortError");
+    if (isTimeout) {
+      throw new TelegramApiError(
+        method,
+        0,
+        `Telegram ${method} request timed out after ${timeoutMs}ms`,
+      );
+    }
+
+    throw new TelegramApiError(
+      method,
+      0,
+      `Telegram ${method} request failed: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  let bodyText: string;
+  try {
+    bodyText = await response.text();
+  } catch (e) {
+    throw new TelegramApiError(
+      method,
+      response.status,
+      `Telegram ${method} response read failed: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+
+  if (!response.ok) {
+    throw new TelegramApiError(
+      method,
+      response.status,
+      `Telegram ${method} returned ${response.status}: ${summarizeBody(bodyText)}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch {
+    throw new TelegramApiError(
+      method,
+      response.status,
+      `Telegram ${method} returned invalid JSON`,
+    );
+  }
+
+  const envelope = parsed as TelegramApiEnvelope<T>;
+  if (envelope.ok !== true) {
+    const statusCode =
+      typeof envelope.error_code === "number"
+        ? envelope.error_code
+        : response.status;
+    const detail =
+      typeof envelope.description === "string"
+        ? envelope.description
+        : "unknown Telegram API error";
+    throw new TelegramApiError(
+      method,
+      statusCode,
+      `Telegram ${method} error: ${detail}`,
+    );
+  }
+
+  return envelope.result as T;
+}
+
+export async function getUpdates(
+  botToken: string,
+  offset?: number,
+  timeoutSec = 20,
+): Promise<TelegramUpdate[]> {
+  const payload: Record<string, unknown> = {
+    timeout: timeoutSec,
+    allowed_updates: ["message"],
+  };
+  if (offset !== undefined) {
+    payload.offset = offset;
+  }
+
+  const requestTimeoutMs = Math.max(5000, (timeoutSec + 10) * 1000);
+  return callTelegramApi<TelegramUpdate[]>(
+    botToken,
+    "getUpdates",
+    payload,
+    requestTimeoutMs,
+  );
+}
+
+export async function sendMessage(
+  botToken: string,
+  chatId: number,
+  text: string,
+  opts: SendMessageOptions = {},
+): Promise<TelegramMessage> {
+  const payload: Record<string, unknown> = {
+    chat_id: chatId,
+    text,
+  };
+  if (opts.threadId !== undefined) {
+    payload.message_thread_id = opts.threadId;
+  }
+  if (opts.parseMode !== undefined) {
+    payload.parse_mode = opts.parseMode;
+  }
+
+  return callTelegramApi<TelegramMessage>(
+    botToken,
+    "sendMessage",
+    payload,
+    15000,
+  );
+}
+
+export function startTelegramIngestionLoop(
+  config: CortexConfig,
+  options?: TelegramIngestionLoopOptions,
+): TelegramIngestionLoop {
+  if (!config.telegramBotToken) {
+    throw new Error("telegramBotToken is required for Telegram ingestion loop");
+  }
+
+  const botToken = config.telegramBotToken;
+  const allowedUserIds = new Set(config.telegramAllowedUserIds ?? []);
+  const onErrorDelayMs = options?.onErrorDelayMs ?? 1000;
+  const onEmptyDelayMs = options?.onEmptyDelayMs ?? 250;
+
+  let running = true;
+  let offset = getTelegramOffset(botToken) ?? undefined;
+
+  const done = (async () => {
+    while (running) {
+      try {
+        const updates = await getUpdates(botToken, offset, 20);
+        if (updates.length === 0) {
+          if (running && onEmptyDelayMs > 0) {
+            await Bun.sleep(onEmptyDelayMs);
+          }
+          continue;
+        }
+
+        let maxUpdateId = -1;
+
+        for (const update of updates) {
+          if (update.update_id > maxUpdateId) {
+            maxUpdateId = update.update_id;
+          }
+
+          const message = update.message;
+          if (!message) continue;
+
+          const text = message.text;
+          const fromId = message.from?.id;
+          const chatId = message.chat?.id;
+          if (
+            typeof text !== "string" ||
+            typeof fromId !== "number" ||
+            typeof chatId !== "number"
+          ) {
+            continue;
+          }
+
+          if (!allowedUserIds.has(fromId)) {
+            continue;
+          }
+
+          const externalMessageId = `${update.update_id}:${message.message_id}`;
+          const topicKey =
+            typeof message.message_thread_id === "number"
+              ? `${chatId}:${message.message_thread_id}`
+              : String(chatId);
+
+          enqueueInboxMessage({
+            source: "telegram",
+            externalMessageId,
+            topicKey,
+            userId: String(fromId),
+            text,
+            occurredAt: message.date * 1000,
+            idempotencyKey: externalMessageId,
+          });
+        }
+
+        if (maxUpdateId >= 0) {
+          offset = maxUpdateId + 1;
+          setTelegramOffset(offset, botToken);
+        }
+      } catch (err) {
+        console.error("cortex: telegram ingestion loop error:", err);
+        if (running && onErrorDelayMs > 0) {
+          await Bun.sleep(onErrorDelayMs);
+        }
+      }
+    }
+  })();
+
+  return {
+    async stop() {
+      running = false;
+      await done;
+    },
+  };
+}
+
+async function sendChunkWithMarkdownFallback(
+  botToken: string,
+  topic: TelegramTopic,
+  chunk: string,
+): Promise<void> {
+  try {
+    await sendMessage(botToken, topic.chatId, chunk, {
+      threadId: topic.threadId,
+      parseMode: "MarkdownV2",
+    });
+  } catch (err) {
+    if (!(err instanceof TelegramApiError) || err.statusCode !== 400) {
+      throw err;
+    }
+
+    await sendMessage(botToken, topic.chatId, chunk, {
+      threadId: topic.threadId,
+    });
+  }
+}
+
+export function startTelegramDeliveryLoop(
+  config: CortexConfig,
+  options?: TelegramDeliveryLoopOptions,
+): TelegramDeliveryLoop {
+  if (!config.telegramBotToken) {
+    throw new Error("telegramBotToken is required for Telegram delivery loop");
+  }
+
+  const botToken = config.telegramBotToken;
+  const maxBatch = options?.maxBatch ?? config.outboxPollDefaultBatch;
+  const leaseSeconds = options?.leaseSeconds ?? config.outboxLeaseSeconds;
+  const maxAttempts = options?.maxAttempts ?? config.outboxMaxAttempts;
+  const onErrorDelayMs = options?.onErrorDelayMs ?? 1000;
+  const onEmptyDelayMs = options?.onEmptyDelayMs ?? 250;
+
+  let running = true;
+
+  const done = (async () => {
+    while (running) {
+      try {
+        const messages = pollOutboxMessages(
+          "telegram",
+          maxBatch,
+          leaseSeconds,
+          maxAttempts,
+        );
+
+        if (messages.length === 0) {
+          if (running && onEmptyDelayMs > 0) {
+            await Bun.sleep(onEmptyDelayMs);
+          }
+          continue;
+        }
+
+        for (const message of messages) {
+          try {
+            const topic = parseTelegramTopicKey(message.topicKey);
+            if (!topic) {
+              throw new Error(
+                `Invalid telegram topic key: ${message.topicKey}`,
+              );
+            }
+
+            const chunks = splitTelegramMessageText(message.text);
+            for (const chunk of chunks) {
+              await sendChunkWithMarkdownFallback(botToken, topic, chunk);
+            }
+
+            ackOutboxMessage(message.messageId, message.leaseToken);
+          } catch (err) {
+            console.error("cortex: telegram delivery message failed:", err);
+          }
+        }
+      } catch (err) {
+        console.error("cortex: telegram delivery loop error:", err);
+        if (running && onErrorDelayMs > 0) {
+          await Bun.sleep(onErrorDelayMs);
+        }
+      }
+    }
+  })();
+
+  return {
+    async stop() {
+      running = false;
+      await done;
+    },
+  };
+}

--- a/test/db-telegram-state.test.ts
+++ b/test/db-telegram-state.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  closeDatabase,
+  getDatabase,
+  getTelegramOffset,
+  initDatabase,
+  setTelegramOffset,
+} from "../src/db";
+
+beforeEach(() => {
+  initDatabase(":memory:");
+});
+
+afterEach(() => {
+  closeDatabase();
+});
+
+describe("telegram_state offset", () => {
+  test("returns null when offset is missing", () => {
+    expect(getTelegramOffset()).toBeNull();
+  });
+
+  test("stores and reads offset", () => {
+    setTelegramOffset(1234);
+    expect(getTelegramOffset()).toBe(1234);
+  });
+
+  test("upsert overwrites existing offset", () => {
+    setTelegramOffset(10);
+    setTelegramOffset(42);
+    expect(getTelegramOffset()).toBe(42);
+  });
+
+  test("stores offsets independently per bot token", () => {
+    setTelegramOffset(100, "token-a");
+    setTelegramOffset(200, "token-b");
+
+    expect(getTelegramOffset("token-a")).toBe(100);
+    expect(getTelegramOffset("token-b")).toBe(200);
+    expect(getTelegramOffset()).toBeNull();
+  });
+
+  test("returns null for invalid stored value", () => {
+    const db = getDatabase();
+    db.prepare(
+      "INSERT INTO telegram_state (key, value) VALUES ('offset', 'nope')",
+    ).run();
+    expect(getTelegramOffset()).toBeNull();
+  });
+});

--- a/test/index-wiring.test.ts
+++ b/test/index-wiring.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "bun:test";
+import type { CortexConfig } from "../src/config";
+import { startCortexRuntime } from "../src/index";
+import { createEmptyRegistry } from "../src/skills";
+
+function testConfig(overrides: Partial<CortexConfig> = {}): CortexConfig {
+  return {
+    host: "127.0.0.1",
+    port: 7751,
+    ingestApiKey: "test-key",
+    synapseUrl: "http://127.0.0.1:7750",
+    engramUrl: "http://127.0.0.1:7749",
+    model: "test-model",
+    activeWindowSize: 10,
+    extractionInterval: 3,
+    turnTtlDays: 30,
+    schedulerTickSeconds: 30,
+    schedulerTimezone: "UTC",
+    telegramAllowedUserIds: [],
+    outboxPollDefaultBatch: 20,
+    outboxLeaseSeconds: 60,
+    outboxMaxAttempts: 10,
+    skillDirs: [],
+    skillConfig: {},
+    toolTimeoutMs: 20000,
+    maxToolRounds: 8,
+    ...overrides,
+  };
+}
+
+describe("index runtime wiring", () => {
+  test("starts telegram ingestion+delivery only when token exists", async () => {
+    const events: string[] = [];
+
+    const runtime = await startCortexRuntime(
+      testConfig({ telegramBotToken: "123:abc" }),
+      createEmptyRegistry(),
+      {
+        startServer: () => {
+          events.push("server:start");
+          return {
+            port: 0,
+            stop: () => {
+              events.push("server:stop");
+            },
+          };
+        },
+        startProcessingLoop: () => {
+          events.push("loop:start");
+          return {
+            stop: async () => {
+              events.push("loop:stop");
+            },
+          };
+        },
+        startTelegramIngestionLoop: () => {
+          events.push("telegram-ingestion:start");
+          return {
+            stop: async () => {
+              events.push("telegram-ingestion:stop");
+            },
+          };
+        },
+        startTelegramDeliveryLoop: () => {
+          events.push("telegram-delivery:start");
+          return {
+            stop: async () => {
+              events.push("telegram-delivery:stop");
+            },
+          };
+        },
+        log: () => {},
+      },
+    );
+
+    expect(events).toEqual([
+      "server:start",
+      "loop:start",
+      "telegram-ingestion:start",
+      "telegram-delivery:start",
+    ]);
+
+    await runtime.stop();
+
+    expect(events).toEqual([
+      "server:start",
+      "loop:start",
+      "telegram-ingestion:start",
+      "telegram-delivery:start",
+      "telegram-delivery:stop",
+      "telegram-ingestion:stop",
+      "loop:stop",
+      "server:stop",
+    ]);
+  });
+
+  test("keeps telegram adapter disabled when token is missing", async () => {
+    const events: string[] = [];
+    const logs: string[] = [];
+
+    const runtime = await startCortexRuntime(
+      testConfig(),
+      createEmptyRegistry(),
+      {
+        startServer: () => {
+          events.push("server:start");
+          return {
+            port: 0,
+            stop: () => {
+              events.push("server:stop");
+            },
+          };
+        },
+        startProcessingLoop: () => {
+          events.push("loop:start");
+          return {
+            stop: async () => {
+              events.push("loop:stop");
+            },
+          };
+        },
+        startTelegramIngestionLoop: () => {
+          throw new Error("telegram ingestion should not start without token");
+        },
+        startTelegramDeliveryLoop: () => {
+          throw new Error("telegram delivery should not start without token");
+        },
+        log: (message) => {
+          logs.push(message);
+        },
+      },
+    );
+
+    await runtime.stop();
+
+    expect(events).toEqual([
+      "server:start",
+      "loop:start",
+      "loop:stop",
+      "server:stop",
+    ]);
+    expect(logs).toContain(
+      "cortex: telegram adapter disabled (no token configured)",
+    );
+  });
+
+  test("cleans up started components when telegram startup fails", async () => {
+    const events: string[] = [];
+
+    await expect(
+      startCortexRuntime(
+        testConfig({ telegramBotToken: "123:abc" }),
+        createEmptyRegistry(),
+        {
+          startServer: () => {
+            events.push("server:start");
+            return {
+              port: 0,
+              stop: () => {
+                events.push("server:stop");
+              },
+            };
+          },
+          startProcessingLoop: () => {
+            events.push("loop:start");
+            return {
+              stop: async () => {
+                events.push("loop:stop");
+              },
+            };
+          },
+          startTelegramIngestionLoop: () => {
+            events.push("telegram-ingestion:start");
+            return {
+              stop: async () => {
+                events.push("telegram-ingestion:stop");
+              },
+            };
+          },
+          startTelegramDeliveryLoop: () => {
+            events.push("telegram-delivery:start");
+            throw new Error("delivery startup failed");
+          },
+          log: () => {},
+        },
+      ),
+    ).rejects.toThrow("delivery startup failed");
+
+    expect(events).toEqual([
+      "server:start",
+      "loop:start",
+      "telegram-ingestion:start",
+      "telegram-delivery:start",
+      "telegram-ingestion:stop",
+      "loop:stop",
+      "server:stop",
+    ]);
+  });
+});

--- a/test/telegram-delivery.test.ts
+++ b/test/telegram-delivery.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { CortexConfig } from "../src/config";
+import {
+  closeDatabase,
+  enqueueOutboxMessage,
+  getOutboxMessage,
+  initDatabase,
+} from "../src/db";
+import {
+  parseTelegramTopicKey,
+  splitTelegramMessageText,
+  startTelegramDeliveryLoop,
+} from "../src/telegram";
+
+const originalFetch = globalThis.fetch;
+
+function testConfig(overrides: Partial<CortexConfig> = {}): CortexConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    ingestApiKey: "test-key",
+    synapseUrl: "http://127.0.0.1:7750",
+    engramUrl: "http://127.0.0.1:7749",
+    model: "test-model",
+    activeWindowSize: 10,
+    extractionInterval: 3,
+    turnTtlDays: 30,
+    schedulerTickSeconds: 30,
+    schedulerTimezone: "UTC",
+    telegramBotToken: "123:abc",
+    telegramAllowedUserIds: [],
+    outboxPollDefaultBatch: 20,
+    outboxLeaseSeconds: 60,
+    outboxMaxAttempts: 10,
+    skillDirs: [],
+    skillConfig: {},
+    toolTimeoutMs: 20000,
+    maxToolRounds: 8,
+    ...overrides,
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1500,
+  pollMs = 10,
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+    }
+    await Bun.sleep(pollMs);
+  }
+}
+
+beforeEach(() => {
+  initDatabase(":memory:");
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  closeDatabase();
+});
+
+describe("telegram delivery helpers", () => {
+  test("parseTelegramTopicKey accepts chat and chat:thread forms", () => {
+    expect(parseTelegramTopicKey("-100")).toEqual({ chatId: -100 });
+    expect(parseTelegramTopicKey("-100:42")).toEqual({
+      chatId: -100,
+      threadId: 42,
+    });
+    expect(parseTelegramTopicKey("bad")).toBeNull();
+    expect(parseTelegramTopicKey("1:2:3")).toBeNull();
+  });
+
+  test("splitTelegramMessageText prefers paragraph, then line boundaries", () => {
+    const text = `${"A".repeat(4090)}\n\n${"B".repeat(300)}\n${"C".repeat(300)}`;
+    const chunks = splitTelegramMessageText(text);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks[0].endsWith("\n\n")).toBe(true);
+    expect(chunks.every((chunk) => chunk.length <= 4096)).toBe(true);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  test("splitTelegramMessageText never exceeds 4096 at boundary edges", () => {
+    const paragraphEdge = `${"A".repeat(4096)}\n\n${"B".repeat(32)}`;
+    const lineEdge = `${"A".repeat(4096)}\n${"B".repeat(32)}`;
+    const wordEdge = `${"A".repeat(4096)} ${"B".repeat(32)}`;
+
+    for (const text of [paragraphEdge, lineEdge, wordEdge]) {
+      const chunks = splitTelegramMessageText(text);
+      expect(chunks.length).toBeGreaterThan(1);
+      expect(chunks.every((chunk) => chunk.length <= 4096)).toBe(true);
+      expect(chunks.join("")).toBe(text);
+    }
+  });
+
+  test("splitTelegramMessageText guarantees forward progress on tiny limits", () => {
+    const text = `\n\n${"a".repeat(10)} ${"b".repeat(10)}`;
+    const chunks = splitTelegramMessageText(text, 1);
+
+    expect(chunks.length).toBe(text.length);
+    expect(chunks.every((chunk) => chunk.length === 1)).toBe(true);
+    expect(chunks.join("")).toBe(text);
+  });
+});
+
+describe("telegram delivery loop", () => {
+  test("falls back to plain text on MarkdownV2 400 and then acks", async () => {
+    const messageId = enqueueOutboxMessage({
+      source: "telegram",
+      topicKey: "-100:7",
+      text: "hello *world*",
+    });
+
+    const requests: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_url: any, init: any) => {
+      const payload = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      requests.push(payload);
+
+      if (payload.parse_mode === "MarkdownV2") {
+        return Response.json({
+          ok: false,
+          error_code: 400,
+          description: "Bad Request: can't parse entities",
+        });
+      }
+
+      return Response.json({
+        ok: true,
+        result: {
+          message_id: 1,
+          date: 1700000000,
+          chat: { id: -100 },
+        },
+      });
+    }) as unknown as typeof fetch;
+
+    const loop = startTelegramDeliveryLoop(testConfig(), {
+      maxBatch: 1,
+      onErrorDelayMs: 1,
+      onEmptyDelayMs: 1,
+    });
+
+    await waitFor(() => getOutboxMessage(messageId)?.status === "delivered");
+    await loop.stop();
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0].parse_mode).toBe("MarkdownV2");
+    expect(requests[1].parse_mode).toBeUndefined();
+    expect(requests[0].message_thread_id).toBe(7);
+    expect(requests[1].message_thread_id).toBe(7);
+  });
+
+  test("does not ack when any chunk fails", async () => {
+    const text = `${"hello ".repeat(800)}\n\n${"world ".repeat(800)}`;
+    const messageId = enqueueOutboxMessage({
+      source: "telegram",
+      topicKey: "-200",
+      text,
+    });
+
+    let callCount = 0;
+    globalThis.fetch = (async (_url: any, _init: any) => {
+      callCount++;
+      if (callCount === 2) {
+        return new Response("upstream error", { status: 500 });
+      }
+
+      return Response.json({
+        ok: true,
+        result: {
+          message_id: callCount,
+          date: 1700000000,
+          chat: { id: -200 },
+        },
+      });
+    }) as unknown as typeof fetch;
+
+    const loop = startTelegramDeliveryLoop(testConfig(), {
+      maxBatch: 1,
+      onErrorDelayMs: 1,
+      onEmptyDelayMs: 1,
+    });
+
+    await waitFor(() => callCount >= 2);
+    await Bun.sleep(30);
+    await loop.stop();
+
+    const row = getOutboxMessage(messageId);
+    expect(row).not.toBeNull();
+    expect(row!.status).not.toBe("delivered");
+  });
+});

--- a/test/telegram-ingestion.test.ts
+++ b/test/telegram-ingestion.test.ts
@@ -1,0 +1,390 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { CortexConfig } from "../src/config";
+import {
+  closeDatabase,
+  getDatabase,
+  getTelegramOffset,
+  initDatabase,
+} from "../src/db";
+import { startTelegramIngestionLoop } from "../src/telegram";
+
+const originalFetch = globalThis.fetch;
+
+function testConfig(overrides: Partial<CortexConfig> = {}): CortexConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    ingestApiKey: "test-key",
+    synapseUrl: "http://127.0.0.1:7750",
+    engramUrl: "http://127.0.0.1:7749",
+    model: "test-model",
+    activeWindowSize: 10,
+    extractionInterval: 3,
+    turnTtlDays: 30,
+    schedulerTickSeconds: 30,
+    schedulerTimezone: "UTC",
+    telegramBotToken: "123:abc",
+    telegramAllowedUserIds: [],
+    outboxPollDefaultBatch: 20,
+    outboxLeaseSeconds: 60,
+    outboxMaxAttempts: 10,
+    skillDirs: [],
+    skillConfig: {},
+    toolTimeoutMs: 20000,
+    maxToolRounds: 8,
+    ...overrides,
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+  pollMs = 10,
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+    }
+    await Bun.sleep(pollMs);
+  }
+}
+
+beforeEach(() => {
+  initDatabase(":memory:");
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  closeDatabase();
+});
+
+describe("telegram ingestion loop", () => {
+  test("enqueues authorized text messages and advances cursor", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls++;
+      if (fetchCalls === 1) {
+        return Response.json({
+          ok: true,
+          result: [
+            {
+              update_id: 100,
+              message: {
+                message_id: 1,
+                date: 1700000000,
+                from: { id: 111 },
+                chat: { id: -42 },
+                text: "blocked",
+              },
+            },
+            {
+              update_id: 101,
+              message: {
+                message_id: 2,
+                date: 1700000001,
+                from: { id: 222 },
+                chat: { id: -42 },
+                message_thread_id: 9,
+                text: "hello from authorized user",
+              },
+            },
+            {
+              update_id: 102,
+            },
+          ],
+        });
+      }
+
+      return Response.json({ ok: true, result: [] });
+    }) as unknown as typeof fetch;
+
+    const loop = startTelegramIngestionLoop(
+      testConfig({ telegramAllowedUserIds: [222] }),
+      { onErrorDelayMs: 1 },
+    );
+
+    await waitFor(() => getTelegramOffset("123:abc") === 103);
+    await loop.stop();
+
+    const db = getDatabase();
+    const rows = db
+      .prepare(
+        "SELECT source, external_message_id, topic_key, user_id, idempotency_key, text, occurred_at FROM inbox_messages ORDER BY created_at ASC",
+      )
+      .all() as Array<{
+      source: string;
+      external_message_id: string;
+      topic_key: string;
+      user_id: string;
+      idempotency_key: string;
+      text: string;
+      occurred_at: number;
+    }>;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].source).toBe("telegram");
+    expect(rows[0].external_message_id).toBe("101:2");
+    expect(rows[0].topic_key).toBe("-42:9");
+    expect(rows[0].user_id).toBe("222");
+    expect(rows[0].idempotency_key).toBe("101:2");
+    expect(rows[0].text).toBe("hello from authorized user");
+    expect(rows[0].occurred_at).toBe(1700000001000);
+  });
+
+  test("empty allowed-user list rejects all messages silently", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls++;
+      if (fetchCalls === 1) {
+        return Response.json({
+          ok: true,
+          result: [
+            {
+              update_id: 7,
+              message: {
+                message_id: 99,
+                date: 1700000100,
+                from: { id: 12345 },
+                chat: { id: 888 },
+                text: "should be ignored",
+              },
+            },
+          ],
+        });
+      }
+      return Response.json({ ok: true, result: [] });
+    }) as unknown as typeof fetch;
+
+    const loop = startTelegramIngestionLoop(
+      testConfig({ telegramAllowedUserIds: [] }),
+      {
+        onErrorDelayMs: 1,
+      },
+    );
+
+    await waitFor(() => getTelegramOffset("123:abc") === 8);
+    await loop.stop();
+
+    const db = getDatabase();
+    const row = db
+      .prepare("SELECT COUNT(*) AS cnt FROM inbox_messages")
+      .get() as { cnt: number };
+    expect(row.cnt).toBe(0);
+  });
+
+  test("restores persisted offset on restart and does not reprocess old updates", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = (async (_url: any, init: any) => {
+      fetchCalls++;
+
+      if (fetchCalls === 1) {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        expect(body).not.toHaveProperty("offset");
+        return Response.json({
+          ok: true,
+          result: [
+            {
+              update_id: 201,
+              message: {
+                message_id: 20,
+                date: 1700000200,
+                from: { id: 222 },
+                chat: { id: -42 },
+                text: "first run message",
+              },
+            },
+          ],
+        });
+      }
+
+      return Response.json({ ok: true, result: [] });
+    }) as unknown as typeof fetch;
+
+    const firstLoop = startTelegramIngestionLoop(
+      testConfig({ telegramAllowedUserIds: [222] }),
+      { onErrorDelayMs: 1 },
+    );
+
+    await waitFor(() => getTelegramOffset("123:abc") === 202);
+    await firstLoop.stop();
+
+    let restartFetchCalls = 0;
+    globalThis.fetch = (async (_url: any, init: any) => {
+      restartFetchCalls++;
+      if (restartFetchCalls === 1) {
+        const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        expect(body.offset).toBe(202);
+      }
+      return Response.json({ ok: true, result: [] });
+    }) as unknown as typeof fetch;
+
+    const secondLoop = startTelegramIngestionLoop(
+      testConfig({ telegramAllowedUserIds: [222] }),
+      { onErrorDelayMs: 1 },
+    );
+
+    await waitFor(() => restartFetchCalls >= 1);
+    await secondLoop.stop();
+
+    const db = getDatabase();
+    const count = db
+      .prepare("SELECT COUNT(*) AS cnt FROM inbox_messages")
+      .get() as { cnt: number };
+    expect(count.cnt).toBe(1);
+  });
+
+  test("deduplicates duplicate update_id:message_id into one inbox message", async () => {
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls++;
+      if (fetchCalls === 1) {
+        return Response.json({
+          ok: true,
+          result: [
+            {
+              update_id: 501,
+              message: {
+                message_id: 77,
+                date: 1700000300,
+                from: { id: 222 },
+                chat: { id: -42 },
+                text: "duplicate candidate",
+              },
+            },
+            {
+              update_id: 501,
+              message: {
+                message_id: 77,
+                date: 1700000300,
+                from: { id: 222 },
+                chat: { id: -42 },
+                text: "duplicate candidate",
+              },
+            },
+          ],
+        });
+      }
+
+      return Response.json({ ok: true, result: [] });
+    }) as unknown as typeof fetch;
+
+    const loop = startTelegramIngestionLoop(
+      testConfig({ telegramAllowedUserIds: [222] }),
+      { onErrorDelayMs: 1 },
+    );
+
+    await waitFor(() => getTelegramOffset("123:abc") === 502);
+    await loop.stop();
+
+    const db = getDatabase();
+    const rows = db
+      .prepare(
+        "SELECT external_message_id, idempotency_key FROM inbox_messages ORDER BY created_at ASC",
+      )
+      .all() as Array<{ external_message_id: string; idempotency_key: string }>;
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].external_message_id).toBe("501:77");
+    expect(rows[0].idempotency_key).toBe("501:77");
+  });
+
+  test("does not reuse cursor when bot token changes", async () => {
+    let botAFetchCalls = 0;
+    globalThis.fetch = (async () => {
+      botAFetchCalls++;
+      if (botAFetchCalls === 1) {
+        return Response.json({
+          ok: true,
+          result: [
+            {
+              update_id: 300,
+              message: {
+                message_id: 1,
+                date: 1700000400,
+                from: { id: 222 },
+                chat: { id: -1 },
+                text: "from bot a",
+              },
+            },
+          ],
+        });
+      }
+
+      return Response.json({ ok: true, result: [] });
+    }) as unknown as typeof fetch;
+
+    const botALoop = startTelegramIngestionLoop(
+      testConfig({
+        telegramBotToken: "token-a",
+        telegramAllowedUserIds: [222],
+      }),
+      { onErrorDelayMs: 1, onEmptyDelayMs: 1 },
+    );
+
+    let botBLoop: ReturnType<typeof startTelegramIngestionLoop> | null = null;
+    try {
+      await waitFor(() => getTelegramOffset("token-a") === 301);
+      await botALoop.stop();
+
+      let firstBody: Record<string, unknown> | null = null;
+      globalThis.fetch = (async (_url: any, init: any) => {
+        if (!firstBody) {
+          firstBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        }
+        return Response.json({ ok: true, result: [] });
+      }) as unknown as typeof fetch;
+
+      botBLoop = startTelegramIngestionLoop(
+        testConfig({
+          telegramBotToken: "token-b",
+          telegramAllowedUserIds: [222],
+        }),
+        { onErrorDelayMs: 1, onEmptyDelayMs: 1 },
+      );
+
+      await waitFor(() => firstBody !== null);
+
+      expect(firstBody).not.toHaveProperty("offset");
+      expect(getTelegramOffset("token-a")).toBe(301);
+      expect(getTelegramOffset("token-b")).toBeNull();
+    } finally {
+      if (botBLoop) {
+        await botBLoop.stop();
+      }
+      await botALoop.stop();
+    }
+  });
+
+  test("stop waits for in-flight poll and exits cleanly", async () => {
+    let releasePoll: (() => void) | null = null;
+    let fetchCalls = 0;
+
+    globalThis.fetch = (async () => {
+      fetchCalls++;
+      await new Promise<void>((resolve) => {
+        releasePoll = resolve;
+      });
+      return Response.json({ ok: true, result: [] });
+    }) as unknown as typeof fetch;
+
+    const loop = startTelegramIngestionLoop(testConfig(), {
+      onErrorDelayMs: 1,
+    });
+
+    await waitFor(() => fetchCalls === 1);
+
+    let stopped = false;
+    const stopPromise = loop.stop().then(() => {
+      stopped = true;
+    });
+
+    await Bun.sleep(20);
+    expect(stopped).toBe(false);
+
+    releasePoll!();
+    await stopPromise;
+    expect(stopped).toBe(true);
+    expect(fetchCalls).toBe(1);
+  });
+});

--- a/test/telegram-roundtrip.test.ts
+++ b/test/telegram-roundtrip.test.ts
@@ -1,0 +1,228 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import type { CortexConfig } from "../src/config";
+import {
+  closeDatabase,
+  getDatabase,
+  getTelegramOffset,
+  initDatabase,
+} from "../src/db";
+import { startProcessingLoop } from "../src/loop";
+import { createEmptyRegistry } from "../src/skills";
+import {
+  startTelegramDeliveryLoop,
+  startTelegramIngestionLoop,
+} from "../src/telegram";
+
+const originalFetch = globalThis.fetch;
+
+let mockSynapse: ReturnType<typeof Bun.serve>;
+let mockEngram: ReturnType<typeof Bun.serve>;
+let mockSynapseUrl: string;
+let mockEngramUrl: string;
+
+beforeAll(() => {
+  mockSynapse = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch: () =>
+      Response.json({
+        id: "chat-roundtrip",
+        object: "chat.completion",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Roundtrip reply from synapse",
+            },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      }),
+  });
+
+  mockEngram = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch: () => Response.json({ memories: [], fallback_mode: false }),
+  });
+
+  mockSynapseUrl = `http://127.0.0.1:${mockSynapse.port}`;
+  mockEngramUrl = `http://127.0.0.1:${mockEngram.port}`;
+});
+
+afterAll(() => {
+  mockSynapse.stop(true);
+  mockEngram.stop(true);
+});
+
+beforeEach(() => {
+  initDatabase(":memory:");
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  closeDatabase();
+});
+
+function testConfig(overrides: Partial<CortexConfig> = {}): CortexConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    ingestApiKey: "test-key",
+    synapseUrl: mockSynapseUrl,
+    engramUrl: mockEngramUrl,
+    model: "test-model",
+    activeWindowSize: 10,
+    extractionInterval: 3,
+    turnTtlDays: 30,
+    schedulerTickSeconds: 30,
+    schedulerTimezone: "UTC",
+    telegramBotToken: "123:abc",
+    telegramAllowedUserIds: [222],
+    outboxPollDefaultBatch: 20,
+    outboxLeaseSeconds: 60,
+    outboxMaxAttempts: 10,
+    skillDirs: [],
+    skillConfig: {},
+    toolTimeoutMs: 20000,
+    maxToolRounds: 8,
+    ...overrides,
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 2500,
+  pollMs = 10,
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+    }
+    await Bun.sleep(pollMs);
+  }
+}
+
+describe("telegram roundtrip", () => {
+  test("ingests update, processes response, delivers outbox, and acks delivered", async () => {
+    let getUpdatesCalls = 0;
+    const sentPayloads: Array<Record<string, unknown>> = [];
+
+    globalThis.fetch = (async (input: any, init: any) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (!url.startsWith("https://api.telegram.org/")) {
+        return originalFetch(input as RequestInfo | URL, init);
+      }
+
+      if (url.endsWith("/getUpdates")) {
+        getUpdatesCalls++;
+        if (getUpdatesCalls === 1) {
+          return Response.json({
+            ok: true,
+            result: [
+              {
+                update_id: 900,
+                message: {
+                  message_id: 11,
+                  date: 1700001000,
+                  from: { id: 222 },
+                  chat: { id: -42 },
+                  message_thread_id: 9,
+                  text: "hello from telegram user",
+                },
+              },
+            ],
+          });
+        }
+
+        return Response.json({ ok: true, result: [] });
+      }
+
+      if (url.endsWith("/sendMessage")) {
+        const payload = JSON.parse(String(init?.body)) as Record<
+          string,
+          unknown
+        >;
+        sentPayloads.push(payload);
+        return Response.json({
+          ok: true,
+          result: {
+            message_id: 501,
+            date: 1700001001,
+            chat: { id: -42 },
+          },
+        });
+      }
+
+      return Response.json(
+        { ok: false, description: "unexpected Telegram method" },
+        { status: 404 },
+      );
+    }) as unknown as typeof fetch;
+
+    const config = testConfig();
+    const processingLoop = startProcessingLoop(config, createEmptyRegistry(), {
+      pollBusyMs: 5,
+      pollIdleMs: 5,
+    });
+    const ingestionLoop = startTelegramIngestionLoop(config, {
+      onErrorDelayMs: 1,
+      onEmptyDelayMs: 1,
+    });
+    const deliveryLoop = startTelegramDeliveryLoop(config, {
+      maxBatch: 2,
+      onErrorDelayMs: 1,
+      onEmptyDelayMs: 1,
+    });
+
+    try {
+      await waitFor(() => {
+        const db = getDatabase();
+        const inboxRow = db
+          .prepare(
+            "SELECT status FROM inbox_messages WHERE source = 'telegram' AND external_message_id = '900:11'",
+          )
+          .get() as { status: string } | null;
+        const outboxRow = db
+          .prepare(
+            "SELECT status FROM outbox_messages WHERE source = 'telegram' AND topic_key = '-42:9' ORDER BY created_at DESC LIMIT 1",
+          )
+          .get() as { status: string } | null;
+
+        return (
+          getTelegramOffset("123:abc") === 901 &&
+          inboxRow?.status === "done" &&
+          outboxRow?.status === "delivered" &&
+          sentPayloads.length === 1
+        );
+      });
+    } finally {
+      await deliveryLoop.stop();
+      await ingestionLoop.stop();
+      await processingLoop.stop();
+    }
+
+    expect(sentPayloads).toHaveLength(1);
+    expect(sentPayloads[0].chat_id).toBe(-42);
+    expect(sentPayloads[0].message_thread_id).toBe(9);
+    expect(sentPayloads[0].text).toBe("Roundtrip reply from synapse");
+    expect(sentPayloads[0].parse_mode).toBe("MarkdownV2");
+  });
+});

--- a/test/telegram.test.ts
+++ b/test/telegram.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { getUpdates, sendMessage, TelegramApiError } from "../src/telegram";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("telegram client", () => {
+  test("getUpdates calls Telegram API with message-only updates", async () => {
+    let capturedUrl = "";
+    let capturedInit: RequestInit | undefined;
+
+    globalThis.fetch = (async (url: any, init: any) => {
+      capturedUrl = String(url);
+      capturedInit = init;
+      return Response.json({ ok: true, result: [{ update_id: 11 }] });
+    }) as unknown as typeof fetch;
+
+    const result = await getUpdates("123:abc", 42, 15);
+
+    expect(result).toEqual([{ update_id: 11 }]);
+    expect(capturedUrl).toBe("https://api.telegram.org/bot123:abc/getUpdates");
+    expect(capturedInit?.method).toBe("POST");
+    expect(capturedInit?.headers).toEqual({
+      "Content-Type": "application/json",
+    });
+    expect(capturedInit?.signal).toBeInstanceOf(AbortSignal);
+
+    const body = JSON.parse(String(capturedInit?.body)) as Record<
+      string,
+      unknown
+    >;
+    expect(body.offset).toBe(42);
+    expect(body.timeout).toBe(15);
+    expect(body.allowed_updates).toEqual(["message"]);
+  });
+
+  test("getUpdates defaults timeout to 20 and omits offset", async () => {
+    let capturedInit: RequestInit | undefined;
+
+    globalThis.fetch = (async (_url: any, init: any) => {
+      capturedInit = init;
+      return Response.json({ ok: true, result: [] });
+    }) as unknown as typeof fetch;
+
+    await getUpdates("123:abc");
+
+    const body = JSON.parse(String(capturedInit?.body)) as Record<
+      string,
+      unknown
+    >;
+    expect(body.timeout).toBe(20);
+    expect(body.allowed_updates).toEqual(["message"]);
+    expect(body).not.toHaveProperty("offset");
+  });
+
+  test("sendMessage calls Telegram API with mapped optional fields", async () => {
+    let capturedUrl = "";
+    let capturedInit: RequestInit | undefined;
+
+    globalThis.fetch = (async (url: any, init: any) => {
+      capturedUrl = String(url);
+      capturedInit = init;
+      return Response.json({
+        ok: true,
+        result: {
+          message_id: 99,
+          date: 123456,
+          chat: { id: 555 },
+          text: "hello",
+          message_thread_id: 7,
+        },
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await sendMessage("123:abc", 555, "hello", {
+      threadId: 7,
+      parseMode: "MarkdownV2",
+    });
+
+    expect(result.message_id).toBe(99);
+    expect(capturedUrl).toBe("https://api.telegram.org/bot123:abc/sendMessage");
+    expect(capturedInit?.method).toBe("POST");
+
+    const body = JSON.parse(String(capturedInit?.body)) as Record<
+      string,
+      unknown
+    >;
+    expect(body.chat_id).toBe(555);
+    expect(body.text).toBe("hello");
+    expect(body.message_thread_id).toBe(7);
+    expect(body.parse_mode).toBe("MarkdownV2");
+  });
+
+  test("throws TelegramApiError for non-2xx response", async () => {
+    globalThis.fetch = (async () =>
+      new Response("bad request details", {
+        status: 400,
+        statusText: "Bad",
+      })) as unknown as typeof fetch;
+
+    try {
+      await sendMessage("123:abc", 555, "hello");
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(TelegramApiError);
+      const err = e as TelegramApiError;
+      expect(err.method).toBe("sendMessage");
+      expect(err.statusCode).toBe(400);
+      expect(err.message).toContain("sendMessage");
+      expect(err.message).toContain("bad request details");
+    }
+  });
+
+  test("throws TelegramApiError on timeout", async () => {
+    globalThis.fetch = (async () => {
+      throw new DOMException("Timed out", "TimeoutError");
+    }) as unknown as typeof fetch;
+
+    try {
+      await getUpdates("123:abc", undefined, 1);
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(TelegramApiError);
+      const err = e as TelegramApiError;
+      expect(err.method).toBe("getUpdates");
+      expect(err.statusCode).toBe(0);
+      expect(err.message).toContain("timed out");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Implement Telegram adapter for Cortex (`#38`) with in-process ingestion and delivery loops.
- Add Telegram config/env support, DB cursor persistence, and runtime startup/shutdown wiring.
- Add comprehensive tests including ingestion/delivery edge cases and a full Telegram roundtrip test.

## Changes
- **Config** (`src/config.ts`): Added `telegramBotToken` and `telegramAllowedUserIds` with env overrides (`CORTEX_TELEGRAM_BOT_TOKEN`, `CORTEX_TELEGRAM_ALLOWED_USER_IDS`)
- **DB** (`src/db.ts`): Added `telegram_state` table with offset get/set helpers
- **Telegram module** (`src/telegram.ts`): 
  - Raw Telegram Bot API client with error handling
  - Ingestion loop: long-poll getUpdates → filter allowed users → enqueue to inbox → persist cursor
  - Delivery loop: poll outbox → split long messages → MarkdownV2 with plain text fallback → ack on success
- **Runtime** (`src/index.ts`): Conditional Telegram adapter startup with graceful shutdown and failure cleanup
- **Tests**: Full coverage including config, DB, client, ingestion, delivery, wiring, and end-to-end roundtrip

## Validation
- `bun test` → 271 passed, 0 failed

Closes #38