### PR TITLE
refactor: extract shared version.ts module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,6 @@ import type { CommandHandler } from "@shetty4l/core/cli";
 import { createLogsCommand, formatUptime, runCli } from "@shetty4l/core/cli";
 import { getConfigDir } from "@shetty4l/core/config";
 import { createDaemonManager } from "@shetty4l/core/daemon";
-import { readVersion } from "@shetty4l/core/version";
 import { join } from "path";
 import { loadConfig } from "./config";
 import {
@@ -40,8 +39,7 @@ import {
 } from "./db";
 import { run } from "./index";
 import { sendMessage } from "./send";
-
-const VERSION = readVersion(join(import.meta.dir, ".."));
+import { VERSION } from "./version";
 
 const HELP = `
 Cortex CLI \u2014 channel-agnostic life assistant runtime

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,6 @@
 import { createLogger } from "@shetty4l/core/log";
 import { ok } from "@shetty4l/core/result";
 import { onShutdown } from "@shetty4l/core/signals";
-import { readVersion } from "@shetty4l/core/version";
-import { join } from "path";
 import type { CortexConfig } from "./config";
 import { loadConfig } from "./config";
 import { initDatabase } from "./db";
@@ -22,8 +20,8 @@ import {
   type TelegramDeliveryLoop,
   type TelegramIngestionLoop,
 } from "./telegram";
+import { VERSION } from "./version";
 
-const VERSION = readVersion(join(import.meta.dir, ".."));
 const log = createLogger("cortex");
 
 interface RuntimeDeps {

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,9 +15,7 @@ import {
   jsonOk,
 } from "@shetty4l/core/http";
 import { createLogger } from "@shetty4l/core/log";
-import { readVersion } from "@shetty4l/core/version";
 import { timingSafeEqual } from "crypto";
-import { join } from "path";
 import type { CortexConfig } from "./config";
 import {
   ackOutboxMessage,
@@ -25,8 +23,8 @@ import {
   findInboxDuplicate,
   pollOutboxMessages,
 } from "./db";
+import { VERSION } from "./version";
 
-const VERSION = readVersion(join(import.meta.dir, ".."));
 const log = createLogger("cortex");
 
 // --- Helpers ---

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,4 @@
+import { readVersion } from "@shetty4l/core/version";
+import { join } from "path";
+
+export const VERSION = readVersion(join(import.meta.dir, ".."));


### PR DESCRIPTION
## Summary
- Created `src/version.ts` that exports a shared `VERSION` constant using `readVersion` from core, matching the pattern used by synapse, engram, and wilson
- Updated `src/cli.ts`, `src/server.ts`, and `src/index.ts` to import `VERSION` from the new module instead of calling `readVersion` inline
- Removed now-unused `readVersion` and `join` imports from `server.ts` and `index.ts` (kept `join` in `cli.ts` where it's still used for other paths)