### PR TITLE
refactor: adopt core CLI command factories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "cortex",
       "dependencies": {
-        "@shetty4l/core": ">=0.1.0 <1.0.0",
+        "@shetty4l/core": "^0.1.30",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.13",
@@ -73,7 +73,7 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.49.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VteIelt78kwzSglOozaQcs6BCS4Lk0j+QA+hGV0W8UeyaqQ3XpbZRhDU55NW1PPvCy1tg4VXsTlEaPovqto7nQ=="],
 
-    "@shetty4l/core": ["@shetty4l/core@0.1.28", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-Xe3QMu3mKoZmIziyNzQsP7CkkxNdYGz9dUwXwC7hkXFtAwhGOwi2KLr0svRLJgP6phUkZcXK01C+i65CcQyj/w=="],
+    "@shetty4l/core": ["@shetty4l/core@0.1.30", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-Q0Po5lEHo7OlG0J+7mPYSoZmqvNvZr4dxnexrLXx/RZI/JnQcvBl4J7mE0luFZWdj3wsvZyDjWyMARMl6IiokA=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@shetty4l/core": ">=0.1.0 <1.0.0"
+    "@shetty4l/core": "^0.1.30"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.13",


### PR DESCRIPTION
## Summary
- Replaces custom daemon lifecycle commands and health command with core's `createDaemonCommands` and `createHealthCommand` factories
- Bumps `@shetty4l/core` to v0.1.30

## Changes
- **`src/cli.ts`**: Replaced `cmdStart`/`cmdStop`/`cmdStatus`/`cmdRestart`/`cmdHealth` with factory calls. Spread `...daemonCmds` into commands map.

## Impact
- 19 insertions, 98 deletions (net **-79 lines**)
- All 274 tests pass, typecheck/lint/format clean