### PR TITLE
fix: extraction guardrail, CLI newlines, auto-discover config, tilde expansion

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@
  * String values in the config file support ${ENV_VAR} interpolation.
  */
 
-import { loadJsonConfig, parsePort } from "@shetty4l/core/config";
+import { expandPath, loadJsonConfig, parsePort } from "@shetty4l/core/config";
 import { createLogger } from "@shetty4l/core/log";
 import type { Result } from "@shetty4l/core/result";
 import { err, ok } from "@shetty4l/core/result";
@@ -378,6 +378,11 @@ export function loadConfig(
       );
     }
     config.maxToolRounds = val;
+  }
+
+  // Path expansion (resolve ~ to home directory)
+  if (config.systemPromptFile) {
+    config.systemPromptFile = expandPath(config.systemPromptFile);
   }
 
   // Required field validation

--- a/src/extraction.ts
+++ b/src/extraction.ts
@@ -354,6 +354,8 @@ function buildExtractionPrompt(
 ): ChatMessage[] {
   let systemContent =
     "You extract durable facts, preferences, and decisions from conversation turns.\n" +
+    "Only extract facts ABOUT THE USER — their name, preferences, plans, decisions, circumstances.\n" +
+    "NEVER extract facts about the assistant itself, its capabilities, or advice it gave.\n" +
     "Respond with ONLY a JSON array — no markdown, no explanation, no surrounding text.\n" +
     'Format: [{ "content": "...", "category": "fact" | "preference" | "decision" }]\n' +
     "Respond with [] if nothing new to extract. Do NOT repeat facts already known.\n" +


### PR DESCRIPTION
## Summary
- Prevents extraction pipeline from storing hallucinated facts about the assistant's own capabilities
- Fixes broken CLI table output when inbox/outbox messages contain newlines
- Rewrites `cmdConfig` to auto-discover config fields (no more missing fields when new config is added)
- Adds `~` expansion for `systemPromptFile` via core's `expandPath()`

## Context
Live production testing revealed a feedback loop: the old system prompt had no capability grounding, so the model hallucinated capabilities ("I can set reminders, manage calendars"). The extraction pipeline stored those hallucinations as facts in Engram, which then reinforced the hallucinations on future queries. 20 poisoned memories had to be manually deleted.

## Changes
- `src/extraction.ts`: Added two guardrail lines to extraction prompt — "Only extract facts ABOUT THE USER" / "NEVER extract facts about the assistant itself, its capabilities, or advice it gave"
- `src/cli.ts`: Replace `msg.text` with `msg.text.replace(/\n/g, " ")` in both `cmdInbox` and `cmdOutbox` text previews
- `src/cli.ts`: Rewrite `cmdConfig` from 25 hardcoded `console.log` lines to `Object.entries(config)` loop with labels/units/mask metadata — new config fields appear automatically
- `src/config.ts`: Import `expandPath` from `@shetty4l/core/config`, apply to `systemPromptFile` after config merge
- `test/config.test.ts`: Added tests for `~` expansion and absolute path passthrough

## Post-merge ops (Mac Mini)
- Clear poisoned turn history: `DELETE FROM turns WHERE topic_key = '6052033650'`
- Clear extraction cursor: `DELETE FROM extraction_cursors WHERE topic_key = '6052033650'`
- Update config.json: change `systemPromptFile` to `~/.local/share/cortex/prompt.md`

297 tests pass, 0 fail.