### PR TITLE
fix(telegram): harden ingestion reliability and MarkdownV2 delivery

### DIFF
--- a/src/telegram-chunker.ts
+++ b/src/telegram-chunker.ts
@@ -1,0 +1,290 @@
+const TELEGRAM_MAX_MESSAGE_LENGTH = 4096;
+
+type Fragment =
+  | { kind: "plain"; text: string }
+  | { kind: "bold"; text: string }
+  | { kind: "italic"; text: string }
+  | { kind: "strike"; text: string }
+  | { kind: "inline_code"; text: string }
+  | { kind: "fenced_code"; text: string }
+  | { kind: "link"; text: string };
+
+function isEscaped(text: string, index: number): boolean {
+  let slashCount = 0;
+  for (let i = index - 1; i >= 0 && text[i] === "\\"; i--) {
+    slashCount++;
+  }
+  return slashCount % 2 === 1;
+}
+
+function hasOddTrailingBackslash(text: string): boolean {
+  let slashCount = 0;
+  for (let i = text.length - 1; i >= 0 && text[i] === "\\"; i--) {
+    slashCount++;
+  }
+  return slashCount % 2 === 1;
+}
+
+function findUnescaped(text: string, needle: string, from: number): number {
+  let index = text.indexOf(needle, from);
+  while (index !== -1 && isEscaped(text, index)) {
+    index = text.indexOf(needle, index + 1);
+  }
+  return index;
+}
+
+function splitPlainText(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= maxLength) {
+      chunks.push(remaining);
+      break;
+    }
+
+    let splitAt = -1;
+    for (const boundary of ["\n\n", "\n", " "]) {
+      const maxBoundaryStart = maxLength - boundary.length;
+      if (maxBoundaryStart < 0) continue;
+      const idx = remaining.lastIndexOf(boundary, maxBoundaryStart);
+      if (idx > 0) {
+        splitAt = idx + boundary.length;
+        break;
+      }
+    }
+
+    if (splitAt === -1) {
+      splitAt = maxLength;
+    }
+
+    while (
+      splitAt > 0 &&
+      hasOddTrailingBackslash(remaining.slice(0, splitAt))
+    ) {
+      splitAt--;
+    }
+
+    if (splitAt === 0) {
+      splitAt = maxLength;
+      while (
+        splitAt > 1 &&
+        hasOddTrailingBackslash(remaining.slice(0, splitAt))
+      ) {
+        splitAt--;
+      }
+    }
+
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt);
+  }
+
+  return chunks;
+}
+
+function parseLink(
+  text: string,
+  start: number,
+): { raw: string; end: number } | null {
+  let i = start + 1;
+  while (i < text.length) {
+    if (text[i] === "]" && !isEscaped(text, i)) {
+      break;
+    }
+    i++;
+  }
+  if (i >= text.length || text[i + 1] !== "(") return null;
+
+  let j = i + 2;
+  while (j < text.length) {
+    if (text[j] === ")" && !isEscaped(text, j)) {
+      const raw = text.slice(start, j + 1);
+      return { raw, end: j + 1 };
+    }
+    j++;
+  }
+  return null;
+}
+
+function tokenizeMarkdownV2(text: string): Fragment[] {
+  const fragments: Fragment[] = [];
+  let i = 0;
+
+  while (i < text.length) {
+    if (text.startsWith("```", i) && !isEscaped(text, i)) {
+      const end = findUnescaped(text, "```", i + 3);
+      if (end !== -1) {
+        fragments.push({ kind: "fenced_code", text: text.slice(i, end + 3) });
+        i = end + 3;
+        continue;
+      }
+    }
+
+    if (text[i] === "`" && !isEscaped(text, i)) {
+      const end = findUnescaped(text, "`", i + 1);
+      if (end !== -1) {
+        fragments.push({ kind: "inline_code", text: text.slice(i, end + 1) });
+        i = end + 1;
+        continue;
+      }
+    }
+
+    if (text[i] === "[" && !isEscaped(text, i)) {
+      const parsed = parseLink(text, i);
+      if (parsed) {
+        fragments.push({ kind: "link", text: parsed.raw });
+        i = parsed.end;
+        continue;
+      }
+    }
+
+    if (["*", "_", "~"].includes(text[i]) && !isEscaped(text, i)) {
+      const marker = text[i];
+      const end = findUnescaped(text, marker, i + 1);
+      if (end !== -1) {
+        const raw = text.slice(i, end + 1);
+        if (marker === "*") {
+          fragments.push({ kind: "bold", text: raw });
+        } else if (marker === "_") {
+          fragments.push({ kind: "italic", text: raw });
+        } else {
+          fragments.push({ kind: "strike", text: raw });
+        }
+        i = end + 1;
+        continue;
+      }
+    }
+
+    const start = i;
+    i++;
+    while (i < text.length) {
+      const startsSpecial =
+        (text.startsWith("```", i) && !isEscaped(text, i)) ||
+        (text[i] === "`" && !isEscaped(text, i)) ||
+        (text[i] === "[" && !isEscaped(text, i)) ||
+        (["*", "_", "~"].includes(text[i]) && !isEscaped(text, i));
+      if (startsSpecial) break;
+      i++;
+    }
+    fragments.push({ kind: "plain", text: text.slice(start, i) });
+  }
+
+  return fragments;
+}
+
+function splitWrappedFragment(
+  text: string,
+  prefix: string,
+  suffix: string,
+  maxLength: number,
+): string[] {
+  const capacity = Math.max(1, maxLength - prefix.length - suffix.length);
+  return splitPlainText(text, capacity).map(
+    (part) => `${prefix}${part}${suffix}`,
+  );
+}
+
+function splitFragment(fragment: Fragment, maxLength: number): string[] {
+  if (fragment.text.length <= maxLength) {
+    return [fragment.text];
+  }
+
+  if (fragment.kind === "plain") {
+    return splitPlainText(fragment.text, maxLength);
+  }
+
+  if (fragment.kind === "bold") {
+    const content = fragment.text.slice(1, -1);
+    return splitWrappedFragment(content, "*", "*", maxLength);
+  }
+
+  if (fragment.kind === "italic") {
+    const content = fragment.text.slice(1, -1);
+    return splitWrappedFragment(content, "_", "_", maxLength);
+  }
+
+  if (fragment.kind === "strike") {
+    const content = fragment.text.slice(1, -1);
+    return splitWrappedFragment(content, "~", "~", maxLength);
+  }
+
+  if (fragment.kind === "inline_code") {
+    const content = fragment.text.slice(1, -1);
+    return splitWrappedFragment(content, "`", "`", maxLength);
+  }
+
+  if (fragment.kind === "fenced_code") {
+    const content = fragment.text.slice(3, -3);
+    return splitWrappedFragment(content, "```", "```", maxLength);
+  }
+
+  const closeBracket = fragment.text.indexOf("](");
+  if (
+    fragment.kind === "link" &&
+    closeBracket !== -1 &&
+    fragment.text.endsWith(")")
+  ) {
+    const textPart = fragment.text.slice(1, closeBracket);
+    const urlPart = fragment.text.slice(closeBracket + 2, -1);
+    const prefix = "[";
+    const middle = `](${urlPart})`;
+    const capacity = Math.max(1, maxLength - prefix.length - middle.length);
+    return splitPlainText(textPart, capacity).map(
+      (part) => `[${part}](${urlPart})`,
+    );
+  }
+
+  return splitPlainText(fragment.text, maxLength);
+}
+
+export function chunkMarkdownV2(
+  convertedMarkdownV2: string,
+  maxLength = TELEGRAM_MAX_MESSAGE_LENGTH,
+): string[] {
+  const limit =
+    Number.isFinite(maxLength) && maxLength > 0 ? Math.floor(maxLength) : 1;
+  if (convertedMarkdownV2.length <= limit) {
+    return [convertedMarkdownV2];
+  }
+
+  const fragments = tokenizeMarkdownV2(convertedMarkdownV2);
+  const pieces = fragments.flatMap((fragment) =>
+    splitFragment(fragment, limit),
+  );
+
+  const chunks: string[] = [];
+  let current = "";
+
+  for (const piece of pieces) {
+    if (piece.length > limit) {
+      const emergencyPieces = splitPlainText(piece, limit);
+      for (const emergencyPiece of emergencyPieces) {
+        if (current.length > 0) {
+          chunks.push(current);
+          current = "";
+        }
+        chunks.push(emergencyPiece);
+      }
+      continue;
+    }
+
+    if (current.length + piece.length <= limit) {
+      current += piece;
+      continue;
+    }
+
+    if (current.length > 0) {
+      chunks.push(current);
+    }
+    current = piece;
+  }
+
+  if (current.length > 0) {
+    chunks.push(current);
+  }
+
+  return chunks;
+}

--- a/src/telegram-format.ts
+++ b/src/telegram-format.ts
@@ -1,0 +1,119 @@
+const SPECIAL_CHARS_TEXT = /[\\_*[\]()~`>#+=|{}.!-]/g;
+const SPECIAL_CHARS_CODE = /[\\`]/g;
+const SPECIAL_CHARS_LINK_URL = /[\\)(]/g;
+const PLACEHOLDER_PREFIX = "\u0000TGMD";
+const PLACEHOLDER_SUFFIX = "\u0000";
+
+export function escapeMarkdownV2Text(text: string): string {
+  return text.replace(SPECIAL_CHARS_TEXT, "\\$&");
+}
+
+export function escapeMarkdownV2Code(text: string): string {
+  return text.replace(SPECIAL_CHARS_CODE, "\\$&");
+}
+
+export function escapeMarkdownV2LinkUrl(url: string): string {
+  let escaped = url.replace(SPECIAL_CHARS_LINK_URL, "\\$&");
+  if (url.startsWith("tg://")) {
+    escaped = escaped.replace(/[?=]/g, "\\$&");
+  }
+  return escaped;
+}
+
+function protectPattern(
+  input: string,
+  pattern: RegExp,
+  slots: string[],
+  render: (...groups: string[]) => string,
+): string {
+  return input.replace(pattern, (_match, ...groups) => {
+    const slotValue = render(...(groups.slice(0, -2) as string[]));
+    const index = slots.push(slotValue) - 1;
+    return `${PLACEHOLDER_PREFIX}${index}${PLACEHOLDER_SUFFIX}`;
+  });
+}
+
+function restorePlaceholders(input: string, slots: string[]): string {
+  const pattern = new RegExp(
+    `${PLACEHOLDER_PREFIX}(\\d+)${PLACEHOLDER_SUFFIX}`,
+    "g",
+  );
+  return input.replace(pattern, (_match, idx) => {
+    const index = Number.parseInt(idx, 10);
+    return slots[index] ?? "";
+  });
+}
+
+function convertLine(line: string): string {
+  let working = line;
+  let bulletPrefix = false;
+
+  const heading = working.match(/^#{1,6}\s+(.+)$/);
+  if (heading) {
+    working = `**${heading[1]}**`;
+  }
+
+  const listItem = working.match(/^[-*+]\s+(.+)$/);
+  if (listItem) {
+    bulletPrefix = true;
+    working = listItem[1];
+  }
+
+  const slots: string[] = [];
+
+  working = protectPattern(working, /`([^`\n]+)`/g, slots, (code) => {
+    return `\`${escapeMarkdownV2Code(code)}\``;
+  });
+
+  working = protectPattern(
+    working,
+    /\[([^\]\n]+)\]\(([^)\n]+)\)/g,
+    slots,
+    (text, url) => {
+      return `[${escapeMarkdownV2Text(text)}](${escapeMarkdownV2LinkUrl(url)})`;
+    },
+  );
+
+  working = protectPattern(working, /\*\*([^*\n]+?)\*\*/g, slots, (text) => {
+    return `*${escapeMarkdownV2Text(text)}*`;
+  });
+
+  working = protectPattern(working, /\*([^*\n]+?)\*/g, slots, (text) => {
+    return `_${escapeMarkdownV2Text(text)}_`;
+  });
+
+  working = protectPattern(working, /~~([^~\n]+?)~~/g, slots, (text) => {
+    return `~${escapeMarkdownV2Text(text)}~`;
+  });
+
+  const escaped = escapeMarkdownV2Text(working);
+  const restored = restorePlaceholders(escaped, slots);
+  return bulletPrefix ? `• ${restored}` : restored;
+}
+
+export function convertMarkdownToTelegram(markdown: string): string {
+  const lines = markdown.split("\n");
+  const result: string[] = [];
+  let inCodeBlock = false;
+
+  for (const line of lines) {
+    if (line.startsWith("```")) {
+      inCodeBlock = !inCodeBlock;
+      result.push(line);
+      continue;
+    }
+
+    if (inCodeBlock) {
+      result.push(escapeMarkdownV2Code(line));
+      continue;
+    }
+
+    result.push(convertLine(line));
+  }
+
+  return result.join("\n");
+}
+
+export function formatForTelegram(markdown: string): string {
+  return convertMarkdownToTelegram(markdown);
+}

--- a/test/telegram-chunker.test.ts
+++ b/test/telegram-chunker.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { chunkMarkdownV2 } from "../src/telegram-chunker";
+import { formatForTelegram } from "../src/telegram-format";
+
+function hasOddTrailingBackslash(text: string): boolean {
+  let slashCount = 0;
+  for (let i = text.length - 1; i >= 0 && text[i] === "\\"; i--) {
+    slashCount++;
+  }
+  return slashCount % 2 === 1;
+}
+
+describe("chunkMarkdownV2", () => {
+  test("keeps every chunk at or below 4096", () => {
+    const input = `${"line ".repeat(3000)}\n\n${"next ".repeat(3000)}`;
+    const chunks = chunkMarkdownV2(input);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 4096)).toBe(true);
+    expect(chunks.join("")).toBe(input);
+  });
+
+  test("does not end chunks with odd trailing backslash", () => {
+    const input = `${"a".repeat(4095)}\\_tail`;
+    const chunks = chunkMarkdownV2(input);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.some((chunk) => hasOddTrailingBackslash(chunk))).toBe(false);
+    expect(chunks.join("")).toBe(input);
+  });
+
+  test("splits long bold content into valid bold fragments", () => {
+    const input = `*${"boldtext ".repeat(900)}*`;
+    const chunks = chunkMarkdownV2(input);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 4096)).toBe(true);
+    expect(chunks.every((chunk) => chunk.startsWith("*"))).toBe(true);
+    expect(chunks.every((chunk) => chunk.endsWith("*"))).toBe(true);
+  });
+
+  test("splits long links without exceeding limit", () => {
+    const input = `[${"linktext ".repeat(1000)}](https://example.com/path)`;
+    const chunks = chunkMarkdownV2(input);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 4096)).toBe(true);
+    expect(chunks.every((chunk) => chunk.startsWith("["))).toBe(true);
+    expect(chunks.every((chunk) => chunk.endsWith(")"))).toBe(true);
+  });
+
+  test("splits long fenced code blocks into fenced chunks", () => {
+    const input = `\`\`\`\n${"code line\n".repeat(1000)}\`\`\``;
+    const chunks = chunkMarkdownV2(input);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.length <= 4096)).toBe(true);
+    expect(chunks.every((chunk) => chunk.startsWith("```"))).toBe(true);
+    expect(chunks.every((chunk) => chunk.endsWith("```"))).toBe(true);
+  });
+
+  test("is deterministic for the same input", () => {
+    const input = formatForTelegram(
+      `${"header\n".repeat(100)}\n**bold** and _escaped_ and [x](https://example.com)`,
+    );
+    const first = chunkMarkdownV2(input);
+    const second = chunkMarkdownV2(input);
+    expect(second).toEqual(first);
+  });
+});

--- a/test/telegram-format.test.ts
+++ b/test/telegram-format.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import {
+  convertMarkdownToTelegram,
+  escapeMarkdownV2Code,
+  escapeMarkdownV2LinkUrl,
+  escapeMarkdownV2Text,
+  formatForTelegram,
+} from "../src/telegram-format";
+
+describe("escapeMarkdownV2Text", () => {
+  test("escapes all special characters", () => {
+    expect(escapeMarkdownV2Text("hello_world")).toBe("hello\\_world");
+    expect(escapeMarkdownV2Text("bold*text")).toBe("bold\\*text");
+    expect(escapeMarkdownV2Text("[link]")).toBe("\\[link\\]");
+    expect(escapeMarkdownV2Text("(paren)")).toBe("\\(paren\\)");
+    expect(escapeMarkdownV2Text("text~strike")).toBe("text\\~strike");
+    expect(escapeMarkdownV2Text("code`block")).toBe("code\\`block");
+    expect(escapeMarkdownV2Text(">quote")).toBe("\\>quote");
+    expect(escapeMarkdownV2Text("#heading")).toBe("\\#heading");
+    expect(escapeMarkdownV2Text("+plus")).toBe("\\+plus");
+    expect(escapeMarkdownV2Text("-dash")).toBe("\\-dash");
+    expect(escapeMarkdownV2Text("=equals")).toBe("\\=equals");
+    expect(escapeMarkdownV2Text("|pipe")).toBe("\\|pipe");
+    expect(escapeMarkdownV2Text("{brace}")).toBe("\\{brace\\}");
+    expect(escapeMarkdownV2Text("dot.")).toBe("dot\\.");
+    expect(escapeMarkdownV2Text("exclaim!")).toBe("exclaim\\!");
+    expect(escapeMarkdownV2Text("back\\slash")).toBe("back\\\\slash");
+  });
+
+  test("escapes multiple special chars in one string", () => {
+    expect(escapeMarkdownV2Text("Hello_World! How are you?")).toBe(
+      "Hello\\_World\\! How are you?",
+    );
+  });
+
+  test("escapes plain underscore-delimited text", () => {
+    expect(escapeMarkdownV2Text("foo_bar_baz")).toBe("foo\\_bar\\_baz");
+    expect(escapeMarkdownV2Text("_existing_")).toBe("\\_existing\\_");
+    expect(escapeMarkdownV2Text("file_name.py")).toBe("file\\_name\\.py");
+  });
+});
+
+describe("escapeMarkdownV2Code", () => {
+  test("escapes backslash and backtick only", () => {
+    expect(escapeMarkdownV2Code("code\\text")).toBe("code\\\\text");
+    expect(escapeMarkdownV2Code("code`text")).toBe("code\\`text");
+    expect(escapeMarkdownV2Code("code_text")).toBe("code_text");
+  });
+});
+
+describe("escapeMarkdownV2LinkUrl", () => {
+  test("escapes parentheses and backslash", () => {
+    expect(escapeMarkdownV2LinkUrl("http://example.com")).toBe(
+      "http://example.com",
+    );
+    expect(escapeMarkdownV2LinkUrl("http://example.com/path(1)")).toBe(
+      "http://example.com/path\\(1\\)",
+    );
+  });
+
+  test("escapes ? and = for tg:// URLs", () => {
+    expect(escapeMarkdownV2LinkUrl("tg://resolve?domain=test")).toBe(
+      "tg://resolve\\?domain\\=test",
+    );
+  });
+});
+
+describe("convertMarkdownToTelegram", () => {
+  test("converts bold from ** to *", () => {
+    expect(convertMarkdownToTelegram("**bold text**")).toBe("*bold text*");
+  });
+
+  test("converts italic from * to _", () => {
+    expect(convertMarkdownToTelegram("*italic text*")).toBe("_italic text_");
+  });
+
+  test("converts strikethrough from ~~ to ~", () => {
+    expect(convertMarkdownToTelegram("~~strike~~")).toBe("~strike~");
+  });
+
+  test("converts headings to bold", () => {
+    expect(convertMarkdownToTelegram("# Heading")).toBe("*Heading*");
+    expect(convertMarkdownToTelegram("## Subheading")).toBe("*Subheading*");
+  });
+
+  test("converts list markers to bullets", () => {
+    expect(convertMarkdownToTelegram("- item")).toBe("• item");
+    expect(convertMarkdownToTelegram("* item")).toBe("• item");
+    expect(convertMarkdownToTelegram("+ item")).toBe("• item");
+  });
+
+  test("preserves inline code with escaping", () => {
+    const result = convertMarkdownToTelegram("Use `code` here");
+    expect(result).toBe("Use `code` here");
+  });
+
+  test("preserves code blocks with escaping", () => {
+    const result = convertMarkdownToTelegram("```\ncode\n```");
+    expect(result).toBe("```\ncode\n```");
+  });
+
+  test("escapes special chars in plain text", () => {
+    expect(convertMarkdownToTelegram("Price: $10.99!")).toBe(
+      "Price: $10\\.99\\!",
+    );
+  });
+
+  test("escapes snake_case and existing underscore pairs in plain text", () => {
+    expect(convertMarkdownToTelegram("foo_bar_baz")).toBe("foo\\_bar\\_baz");
+    expect(convertMarkdownToTelegram("_existing_")).toBe("\\_existing\\_");
+    expect(convertMarkdownToTelegram("file_name.py")).toBe("file\\_name\\.py");
+  });
+
+  test("handles mixed content", () => {
+    const input = "# Title\n\n**bold** and *italic* with `code`";
+    const result = convertMarkdownToTelegram(input);
+    expect(result).toContain("*Title*");
+    expect(result).toContain("*bold*");
+    expect(result).toContain("_italic_");
+    expect(result).toContain("`code`");
+  });
+
+  test("preserves explicit markdown and escapes plain underscores in mixed text", () => {
+    const result = convertMarkdownToTelegram("**bold** and snake_case");
+    expect(result).toBe("*bold* and snake\\_case");
+  });
+
+  test("handles links", () => {
+    const result = convertMarkdownToTelegram("[example](http://example.com)");
+    expect(result).toContain("[example]");
+    expect(result).toContain("http://example.com");
+  });
+});
+
+describe("formatForTelegram", () => {
+  test("is an alias for convertMarkdownToTelegram", () => {
+    const input = "**bold** text";
+    expect(formatForTelegram(input)).toBe(convertMarkdownToTelegram(input));
+  });
+});

--- a/test/telegram-roundtrip.test.ts
+++ b/test/telegram-roundtrip.test.ts
@@ -223,6 +223,6 @@ describe("telegram roundtrip", () => {
     expect(sentPayloads[0].chat_id).toBe(-42);
     expect(sentPayloads[0].message_thread_id).toBe(9);
     expect(sentPayloads[0].text).toBe("Roundtrip reply from synapse");
-    expect(sentPayloads[0].parse_mode).toBeUndefined();
+    expect(sentPayloads[0].parse_mode).toBe("MarkdownV2");
   });
 });


### PR DESCRIPTION
## Summary
- Fix Telegram ingestion cursor semantics to be retry-first: stop cursor advancement at the first retryable enqueue failure so updates are retried instead of dropped.
- Add robust Telegram MarkdownV2 formatting + fragment-based chunking so each outgoing chunk stays <=4096 chars and remains parse-safe (no broken entities / trailing escape boundaries).
- Improve Telegram operability with startup warnings/details, ack conflict observability, and cleaner ingestion cancellation behavior.

## Validation
- bun run validate

## Notes
- Review was run against explicit acceptance criteria (block only on blocker/high issues tied to chunk validity, parse safety, and delivery-loss risk).
- Closes #39