### PR TITLE
feat: configurable synapse timeout

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -31,6 +31,7 @@ export interface AgentConfig {
   toolTimeoutMs: number;
   maxToolRounds: number;
   skillConfig: Record<string, unknown>;
+  synapseTimeoutMs?: number;
 }
 
 export interface AgentResult {
@@ -66,7 +67,13 @@ export async function runAgentLoop(opts: {
 
   while (true) {
     // Call LLM
-    const result = await chat(messages, config.model, config.synapseUrl, tools);
+    const result = await chat(
+      messages,
+      config.model,
+      config.synapseUrl,
+      tools,
+      config.synapseTimeoutMs,
+    );
     if (!result.ok) {
       return err(result.error);
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,9 @@ export interface CortexConfig {
   skillConfig: Record<string, Record<string, unknown>>;
   toolTimeoutMs: number;
   maxToolRounds: number;
+
+  // Synapse
+  synapseTimeoutMs: number;
 }
 
 // --- Defaults ---
@@ -86,6 +89,7 @@ const DEFAULTS: Omit<
   skillConfig: {},
   toolTimeoutMs: 20000,
   maxToolRounds: 8,
+  synapseTimeoutMs: 60_000,
 };
 
 // --- Validation ---
@@ -193,6 +197,7 @@ function validateConfig(raw: unknown): Result<Partial<CortexConfig>> {
     { key: "outboxMaxAttempts", min: 1 },
     { key: "toolTimeoutMs", min: 1000 },
     { key: "maxToolRounds", min: 1, max: 20 },
+    { key: "synapseTimeoutMs", min: 5_000 },
   ];
 
   for (const field of numericFields) {

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -167,6 +167,7 @@ export function startProcessingLoop(
                 toolTimeoutMs: config.toolTimeoutMs,
                 maxToolRounds: config.maxToolRounds,
                 skillConfig: config.skillConfig,
+                synapseTimeoutMs: config.synapseTimeoutMs,
               },
             });
 
@@ -194,6 +195,8 @@ export function startProcessingLoop(
               messages,
               config.model,
               config.synapseUrl,
+              undefined,
+              config.synapseTimeoutMs,
             );
 
             if (result.ok) {

--- a/src/synapse.ts
+++ b/src/synapse.ts
@@ -67,9 +67,11 @@ export async function chat(
   model: string,
   synapseUrl: string,
   tools?: OpenAITool[],
+  timeoutMs?: number,
 ): Promise<Result<ChatResponse>> {
   const url = `${synapseUrl}/v1/chat/completions`;
   const startMs = performance.now();
+  const effectiveTimeout = timeoutMs ?? REQUEST_TIMEOUT_MS;
 
   const requestBody: Record<string, unknown> = {
     model,
@@ -86,11 +88,11 @@ export async function chat(
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(requestBody),
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      signal: AbortSignal.timeout(effectiveTimeout),
     });
   } catch (e) {
     if (e instanceof DOMException && e.name === "TimeoutError") {
-      return err(`Synapse request timed out after ${REQUEST_TIMEOUT_MS}ms`);
+      return err(`Synapse request timed out after ${effectiveTimeout}ms`);
     }
     if (e instanceof DOMException && e.name === "AbortError") {
       return err("Synapse request was aborted");

--- a/test/cli-send.test.ts
+++ b/test/cli-send.test.ts
@@ -64,6 +64,7 @@ function testConfig(port: number): CortexConfig {
     skillConfig: {},
     toolTimeoutMs: 20000,
     maxToolRounds: 8,
+    synapseTimeoutMs: 60_000,
   };
 }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -57,6 +57,7 @@ describe("config", () => {
     expect(config.skillDirs).toEqual([]);
     expect(config.toolTimeoutMs).toBe(20000);
     expect(config.maxToolRounds).toBe(8);
+    expect(config.synapseTimeoutMs).toBe(60_000);
     expect(config.ingestApiKey).toBeUndefined();
     expect(config.model).toBeUndefined();
     expect(config.extractionModel).toBeUndefined();
@@ -444,6 +445,62 @@ describe("config", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toContain("CORTEX_MAX_TOOL_ROUNDS");
+  });
+
+  // --- systemPromptFile tests ---
+
+  test("synapseTimeoutMs defaults to 60_000", () => {
+    process.env.CORTEX_CONFIG_PATH = "/nonexistent/config.json";
+    const result = loadConfig({ quiet: true, skipRequiredChecks: true });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.synapseTimeoutMs).toBe(60_000);
+  });
+
+  test("loads custom synapseTimeoutMs from config file", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "cortex-test-"));
+    const configPath = join(tmpDir, "config.json");
+
+    writeFileSync(configPath, JSON.stringify({ synapseTimeoutMs: 90_000 }));
+    process.env.CORTEX_CONFIG_PATH = configPath;
+
+    const result = loadConfig({ quiet: true, skipRequiredChecks: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.synapseTimeoutMs).toBe(90_000);
+
+    rmSync(tmpDir, { recursive: true });
+  });
+
+  test("returns error when synapseTimeoutMs is below minimum (5_000)", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "cortex-test-"));
+    const configPath = join(tmpDir, "config.json");
+
+    writeFileSync(configPath, JSON.stringify({ synapseTimeoutMs: 3_000 }));
+    process.env.CORTEX_CONFIG_PATH = configPath;
+
+    const result = loadConfig({ quiet: true, skipRequiredChecks: true });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("must be >= 5000");
+
+    rmSync(tmpDir, { recursive: true });
+  });
+
+  test("returns error when synapseTimeoutMs is not an integer", () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), "cortex-test-"));
+    const configPath = join(tmpDir, "config.json");
+
+    writeFileSync(configPath, JSON.stringify({ synapseTimeoutMs: 10000.5 }));
+    process.env.CORTEX_CONFIG_PATH = configPath;
+
+    const result = loadConfig({ quiet: true, skipRequiredChecks: true });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("must be an integer");
+
+    rmSync(tmpDir, { recursive: true });
   });
 
   // --- systemPromptFile tests ---

--- a/test/extraction.test.ts
+++ b/test/extraction.test.ts
@@ -122,6 +122,7 @@ function testConfig(overrides?: Partial<CortexConfig>): CortexConfig {
     skillConfig: {},
     toolTimeoutMs: 20000,
     maxToolRounds: 8,
+    synapseTimeoutMs: 60_000,
     ...overrides,
   };
 }

--- a/test/health.test.ts
+++ b/test/health.test.ts
@@ -31,6 +31,7 @@ describe("health endpoint", () => {
       skillConfig: {},
       toolTimeoutMs: 20000,
       maxToolRounds: 8,
+      synapseTimeoutMs: 60_000,
     };
 
     initDatabase(":memory:");

--- a/test/index-wiring.test.ts
+++ b/test/index-wiring.test.ts
@@ -26,6 +26,7 @@ function testConfig(overrides: Partial<CortexConfig> = {}): CortexConfig {
     skillConfig: {},
     toolTimeoutMs: 20000,
     maxToolRounds: 8,
+    synapseTimeoutMs: 60_000,
     ...overrides,
   };
 }

--- a/test/ingest.test.ts
+++ b/test/ingest.test.ts
@@ -25,6 +25,7 @@ function makeConfig(): CortexConfig {
     skillConfig: {},
     toolTimeoutMs: 20000,
     maxToolRounds: 8,
+    synapseTimeoutMs: 60_000,
   };
 }
 

--- a/test/loop.test.ts
+++ b/test/loop.test.ts
@@ -108,6 +108,7 @@ function testConfig(): CortexConfig {
     skillConfig: {},
     toolTimeoutMs: 20000,
     maxToolRounds: 8,
+    synapseTimeoutMs: 60_000,
   };
 }
 

--- a/test/outbox-ack.test.ts
+++ b/test/outbox-ack.test.ts
@@ -39,6 +39,7 @@ function makeConfig(): CortexConfig {
     skillConfig: {},
     toolTimeoutMs: 20000,
     maxToolRounds: 8,
+    synapseTimeoutMs: 60_000,
   };
 }
 

--- a/test/outbox-poll.test.ts
+++ b/test/outbox-poll.test.ts
@@ -39,6 +39,7 @@ function makeConfig(): CortexConfig {
     skillConfig: {},
     toolTimeoutMs: 20000,
     maxToolRounds: 8,
+    synapseTimeoutMs: 60_000,
   };
 }
 

--- a/test/receive.test.ts
+++ b/test/receive.test.ts
@@ -33,6 +33,7 @@ function makeConfig(): CortexConfig {
     skillConfig: {},
     toolTimeoutMs: 20000,
     maxToolRounds: 8,
+    synapseTimeoutMs: 60_000,
   };
 }
 

--- a/test/telegram-delivery.test.ts
+++ b/test/telegram-delivery.test.ts
@@ -78,6 +78,7 @@ function testConfig(overrides: Partial<CortexConfig> = {}): CortexConfig {
     skillConfig: {},
     toolTimeoutMs: 20000,
     maxToolRounds: 8,
+    synapseTimeoutMs: 60_000,
     ...overrides,
   };
 }

--- a/test/telegram-ingestion.test.ts
+++ b/test/telegram-ingestion.test.ts
@@ -60,6 +60,7 @@ function testConfig(overrides: Partial<CortexConfig> = {}): CortexConfig {
     skillConfig: {},
     toolTimeoutMs: 20000,
     maxToolRounds: 8,
+    synapseTimeoutMs: 60_000,
     ...overrides,
   };
 }

--- a/test/telegram-roundtrip.test.ts
+++ b/test/telegram-roundtrip.test.ts
@@ -101,6 +101,7 @@ function testConfig(overrides: Partial<CortexConfig> = {}): CortexConfig {
     skillConfig: {},
     toolTimeoutMs: 20000,
     maxToolRounds: 8,
+    synapseTimeoutMs: 60_000,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- Add `synapseTimeoutMs` to CortexConfig (default `60_000`, min `5_000`)
- Accept optional `timeoutMs` param in `synapse.chat()`
- Pass `config.synapseTimeoutMs` through `loop.ts` and `agent.ts`
- Existing timeout constant (`30_000`) kept as fallback default for direct callers

## Testing
- New config validation tests for synapseTimeoutMs (default, load from file, reject below min, reject non-integer)
- testConfig() updated with field across all 12 test files
- All 415 tests pass (1431 assertions)

## Acceptance Criteria
1. ✅ synapseTimeoutMs in CortexConfig, default 60_000, min 5_000
2. ✅ synapse.chat() accepts optional timeoutMs, falls back to REQUEST_TIMEOUT_MS (30_000)
3. ✅ loop.ts and agent.ts pass config.synapseTimeoutMs through
4. ✅ All 415 tests pass