### PR TITLE
fix: include response text preview in delivery logs

### DIFF
--- a/src/channels/telegram/index.ts
+++ b/src/channels/telegram/index.ts
@@ -282,7 +282,13 @@ export class TelegramChannel implements Channel {
               ackResult === "delivered" ||
               ackResult === "already_delivered"
             ) {
-              log(`delivered [${message.topicKey}] (${chunks.length} chunks)`);
+              const preview =
+                message.text.length > 120
+                  ? `${message.text.slice(0, 117)}...`
+                  : message.text;
+              log(
+                `delivered [${message.topicKey}] (${chunks.length} chunks): ${preview}`,
+              );
             } else if (ackResult === "lease_conflict") {
               log(
                 `ack lease_conflict for [${message.topicKey}] (messageId=${message.messageId}) — lease may have expired during slow delivery`,


### PR DESCRIPTION
## Summary
Add response text preview (first 120 chars) to Telegram delivery log line.

Before: `delivered [6052033650] (1 chunks)`
After:  `delivered [6052033650] (1 chunks): I can help you with scheduling...`

Gives visibility into both input and output from cortex logs without needing to check Telegram.