### PR TITLE
fix: include response text preview in processing loop logs

### DIFF
--- a/src/loop.ts
+++ b/src/loop.ts
@@ -239,7 +239,13 @@ export function startProcessingLoop(
 
             completeInboxMessage(message.id);
 
-            log(`[${message.topic_key}] done in ${elapsed}s`);
+            const responsePreview =
+              responseText.length > 120
+                ? `${responseText.slice(0, 117)}...`
+                : responseText;
+            log(
+              `[${message.topic_key}] done in ${elapsed}s: ${responsePreview}`,
+            );
           } else {
             log(`[${message.topic_key}] failed in ${elapsed}s: ${errorMsg}`);
             completeInboxMessage(message.id, errorMsg);


### PR DESCRIPTION
## Summary
Add first 120 chars of LLM response to the processing loop's `done` log line.

Before: `[topicKey] done in 47.9s`
After:  `[topicKey] done in 47.9s: I can help you with scheduling...`

Channel-agnostic: works for CLI, Telegram, calendar, silent — any channel.
This complements the Telegram delivery log preview added in #73.