### PR TITLE
feat: add built-in tools, output routing, and idleTimeout

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "cortex",
       "dependencies": {
-        "@shetty4l/core": "^0.1.30",
+        "@shetty4l/core": "^0.1.33",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.13",
@@ -73,7 +73,7 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.49.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VteIelt78kwzSglOozaQcs6BCS4Lk0j+QA+hGV0W8UeyaqQ3XpbZRhDU55NW1PPvCy1tg4VXsTlEaPovqto7nQ=="],
 
-    "@shetty4l/core": ["@shetty4l/core@0.1.30", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-Q0Po5lEHo7OlG0J+7mPYSoZmqvNvZr4dxnexrLXx/RZI/JnQcvBl4J7mE0luFZWdj3wsvZyDjWyMARMl6IiokA=="],
+    "@shetty4l/core": ["@shetty4l/core@0.1.33", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-k7/+4gULGXDOdnqLAFU7CJbCCUYP81xByewEtuKY27r6fj+uE3zvd7MQJ5R6LHQ0XmAkmMKRp/yrVXOHu4COyQ=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@shetty4l/core": "^0.1.30"
+    "@shetty4l/core": "^0.1.33"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.13",

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,6 +67,9 @@ export interface CortexConfig {
   // Thalamus
   thalamusModel: string;
   thalamusSyncIntervalMs: number;
+
+  // Output routing
+  silentChannelAlias?: string;
 }
 
 // --- Defaults ---
@@ -150,6 +153,7 @@ function validateConfig(raw: unknown): Result<Partial<CortexConfig>> {
     { key: "telegramBotToken", label: "telegramBotToken" },
     { key: "systemPromptFile", label: "systemPromptFile" },
     { key: "thalamusModel", label: "thalamusModel" },
+    { key: "silentChannelAlias", label: "silentChannelAlias" },
   ];
 
   for (const field of stringFields) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ import { startServer } from "./server";
 import { createEmptyRegistry, loadSkills, type SkillRegistry } from "./skills";
 import { Thalamus } from "./thalamus";
 import { Tick } from "./tick";
+import { type BuiltinToolContext, createCombinedRegistry } from "./tools";
+import { createSendMessageTool } from "./tools/send-message";
 import { VERSION } from "./version";
 
 const log = createLogger("cortex");
@@ -81,10 +83,23 @@ export async function startCortexRuntime(
   const server = deps.startServer(config, thalamus);
   deps.log(`listening on http://${config.host}:${config.port}`);
 
-  const loop = deps.startProcessingLoop(config, registry);
+  // Create channel registry (needed by built-in tools)
+  const channels = deps.createChannelRegistry(config, thalamus);
+
+  // Create built-in tools with mutable per-message context
+  const builtinCtx: BuiltinToolContext = { topicKey: "" };
+  const builtinTools = [createSendMessageTool(channels)];
+  const combinedRegistry = createCombinedRegistry(
+    builtinTools,
+    registry,
+    () => builtinCtx,
+  );
+
+  const loop = deps.startProcessingLoop(config, combinedRegistry, {
+    builtinContext: builtinCtx,
+  });
   deps.log("processing loop started");
 
-  const channels = deps.createChannelRegistry(config, thalamus);
   await channels.startAll();
 
   await thalamus.start();

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -31,6 +31,8 @@ import { buildPrompt, loadAndRenderSystemPrompt } from "./prompt";
 import type { SkillRegistry } from "./skills";
 import type { OpenAITool } from "./synapse";
 import { chat } from "./synapse";
+import type { BuiltinToolContext } from "./tools";
+import { resolveOutputChannel } from "./tools";
 
 // --- Constants ---
 
@@ -67,6 +69,8 @@ export interface ProcessingLoopOptions {
   pollBusyMs?: number;
   /** Override idle poll interval (ms). Default: 2000. */
   pollIdleMs?: number;
+  /** Mutable context shared with built-in tools (topicKey updated per message). */
+  builtinContext?: BuiltinToolContext;
 }
 
 /**
@@ -85,6 +89,7 @@ export function startProcessingLoop(
   let running = true;
   const pollBusyMs = options?.pollBusyMs ?? DEFAULT_POLL_BUSY_MS;
   const pollIdleMs = options?.pollIdleMs ?? DEFAULT_POLL_IDLE_MS;
+  const builtinCtx = options?.builtinContext;
 
   if (!config.extractionModel) {
     log("extraction disabled — no extractionModel configured");
@@ -118,6 +123,11 @@ export function startProcessingLoop(
         if (message) {
           delay = pollBusyMs;
           const startMs = performance.now();
+
+          // Update built-in tool context for this message
+          if (builtinCtx) {
+            builtinCtx.topicKey = message.topic_key;
+          }
 
           const preview =
             message.text.length > 60
@@ -232,7 +242,7 @@ export function startProcessingLoop(
 
             // 8. Write to outbox
             enqueueOutboxMessage({
-              channel: message.channel,
+              channel: resolveOutputChannel(message.channel, config),
               topicKey: message.topic_key,
               text: responseText,
             });

--- a/src/server.ts
+++ b/src/server.ts
@@ -351,6 +351,7 @@ export function startServer(
     port: config.port,
     host: config.host,
     version: VERSION,
+    idleTimeout: 120,
     onRequest: async (req: Request, url: URL) => {
       const start = performance.now();
       let response: Response | null = null;

--- a/src/thalamus/index.ts
+++ b/src/thalamus/index.ts
@@ -203,7 +203,7 @@ export class Thalamus {
     // Create inbox messages for each triaged group
     for (const item of items) {
       const idempotencyHash = [...item.rawBufferIds].sort().join(",");
-      const idempotencyKey = `thalamus-sync:${idempotencyHash}`;
+      const idempotencyKey = `thalamus-sync:${item.topicKey}:${idempotencyHash}`;
 
       enqueueInboxMessage({
         channel: "thalamus",

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,0 +1,97 @@
+/**
+ * Built-in tools for Cortex.
+ *
+ * Built-in tools are first-party primitives that run inside the agent loop
+ * with direct access to cortex internals (outbox, channels, config).
+ * They are NOT namespaced — tool names are bare (e.g. "send_message").
+ *
+ * External skills loaded from skillDirs are namespaced as "skillId.toolName".
+ */
+
+import type { Result } from "@shetty4l/core/result";
+import type { CortexConfig } from "../config";
+import type { SkillRegistry, SkillToolResult, ToolDefinition } from "../skills";
+
+// --- Types ---
+
+/** Mutable context updated per-message in the processing loop. */
+export interface BuiltinToolContext {
+  /** Topic key of the message currently being processed. */
+  topicKey: string;
+}
+
+/** A built-in tool with direct access to cortex internals. */
+export interface BuiltinTool {
+  readonly definition: ToolDefinition;
+  execute(
+    argsJson: string,
+    ctx: BuiltinToolContext,
+  ): Promise<Result<SkillToolResult>>;
+}
+
+// --- Output channel resolution ---
+
+/** Channels that are internal (system) and should not receive user-facing responses. */
+const SYSTEM_CHANNELS = new Set(["thalamus", "calendar"]);
+
+/**
+ * Resolve the output channel for a response.
+ *
+ * - If the input channel is a system channel, route to "silent".
+ * - If the channel is "silent" and an alias is configured, redirect to the alias.
+ * - Otherwise, return the channel unchanged (echo back to sender).
+ */
+export function resolveOutputChannel(
+  inputChannel: string,
+  config: Pick<CortexConfig, "silentChannelAlias">,
+): string {
+  const channel = SYSTEM_CHANNELS.has(inputChannel) ? "silent" : inputChannel;
+  if (channel === "silent" && config.silentChannelAlias) {
+    return config.silentChannelAlias;
+  }
+  return channel;
+}
+
+// --- Combined registry ---
+
+/**
+ * Create a unified SkillRegistry that dispatches to built-in tools first,
+ * then falls through to the external skill registry.
+ *
+ * Built-in tools receive a BuiltinToolContext (topicKey, etc.) instead of
+ * the SkillRuntimeContext used by external skills.
+ *
+ * @param builtinTools Array of built-in tool definitions + executors.
+ * @param skillRegistry External skill registry loaded from skillDirs.
+ * @param getContext Closure that returns the current per-message context.
+ */
+export function createCombinedRegistry(
+  builtinTools: BuiltinTool[],
+  skillRegistry: SkillRegistry,
+  getContext: () => BuiltinToolContext,
+): SkillRegistry {
+  const builtinMap = new Map(builtinTools.map((t) => [t.definition.name, t]));
+
+  const allTools: ReadonlyArray<ToolDefinition> = [
+    ...builtinTools.map((t) => t.definition),
+    ...skillRegistry.tools,
+  ];
+
+  return {
+    tools: allTools,
+
+    async executeTool(name, argumentsJson, ctx) {
+      const builtin = builtinMap.get(name);
+      if (builtin) {
+        return builtin.execute(argumentsJson, getContext());
+      }
+      return skillRegistry.executeTool(name, argumentsJson, ctx);
+    },
+
+    isMutating(name) {
+      const builtin = builtinMap.get(name);
+      if (builtin) return builtin.definition.mutatesState;
+      return skillRegistry.isMutating(name);
+    },
+  };
+}

--- a/src/tools/send-message.ts
+++ b/src/tools/send-message.ts
@@ -1,0 +1,72 @@
+/**
+ * send_message built-in tool.
+ *
+ * Allows the agent to proactively send a message to the user on a
+ * specific channel. Validates the channel exists and can deliver,
+ * then writes to the outbox for async delivery.
+ */
+
+import { err, ok } from "@shetty4l/core/result";
+import type { ChannelRegistry } from "../channels";
+import { enqueueOutboxMessage } from "../db";
+import type { BuiltinTool, BuiltinToolContext } from "./index";
+
+export function createSendMessageTool(
+  channelRegistry: ChannelRegistry,
+): BuiltinTool {
+  return {
+    definition: {
+      name: "send_message",
+      description:
+        "Send a message to the user on a specific channel (e.g. 'telegram'). Use this to proactively share information.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          channel: {
+            type: "string",
+            description: "Target delivery channel (e.g. 'telegram')",
+          },
+          text: {
+            type: "string",
+            description: "Message text to send",
+          },
+        },
+        required: ["channel", "text"],
+      },
+      mutatesState: true,
+    },
+
+    async execute(argsJson: string, ctx: BuiltinToolContext) {
+      const args = JSON.parse(argsJson) as {
+        channel?: string;
+        text?: string;
+      };
+
+      if (!args.channel || typeof args.channel !== "string") {
+        return err("channel is required and must be a string");
+      }
+      if (!args.text || typeof args.text !== "string") {
+        return err("text is required and must be a string");
+      }
+
+      // Validate channel exists and can deliver
+      const channel = channelRegistry.get(args.channel);
+      if (!channel) {
+        return err(`unknown channel: '${args.channel}'`);
+      }
+      if (!channel.canDeliver) {
+        return err(`channel '${args.channel}' cannot deliver messages`);
+      }
+
+      enqueueOutboxMessage({
+        channel: args.channel,
+        topicKey: ctx.topicKey,
+        text: args.text,
+      });
+
+      return ok({
+        content: `Message queued for delivery on ${args.channel}`,
+      });
+    },
+  };
+}

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1,0 +1,281 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { ChannelRegistry } from "../src/channels";
+import { SilentChannel } from "../src/channels/silent";
+import { closeDatabase, initDatabase } from "../src/db";
+import type { SkillRegistry } from "../src/skills";
+import {
+  type BuiltinToolContext,
+  createCombinedRegistry,
+  resolveOutputChannel,
+} from "../src/tools";
+import { createSendMessageTool } from "../src/tools/send-message";
+
+// --- Helpers ---
+
+/** Minimal deliverable channel for testing. */
+class FakeDeliverChannel {
+  readonly name = "telegram";
+  readonly canReceive = true;
+  readonly canDeliver = true;
+  readonly mode = "realtime" as const;
+  readonly priority = 0;
+  async start() {}
+  async stop() {}
+  async sync() {}
+}
+
+function makeChannelRegistry(
+  ...extra: Array<{ name: string; canDeliver: boolean }>
+) {
+  const registry = new ChannelRegistry();
+  for (const ch of extra) {
+    registry.register({
+      name: ch.name,
+      canReceive: true,
+      canDeliver: ch.canDeliver,
+      mode: "realtime" as const,
+      priority: 0,
+      start: async () => {},
+      stop: async () => {},
+      sync: async () => {},
+    });
+  }
+  registry.register(new SilentChannel());
+  return registry;
+}
+
+function emptySkillRegistry(): SkillRegistry {
+  return {
+    tools: [],
+    async executeTool() {
+      throw new Error("no skills");
+    },
+    isMutating() {
+      return false;
+    },
+  };
+}
+
+// --- resolveOutputChannel ---
+
+describe("resolveOutputChannel", () => {
+  test("echoes back user-facing channels unchanged", () => {
+    expect(resolveOutputChannel("telegram", {})).toBe("telegram");
+  });
+
+  test("routes thalamus to silent", () => {
+    expect(resolveOutputChannel("thalamus", {})).toBe("silent");
+  });
+
+  test("routes calendar to silent", () => {
+    expect(resolveOutputChannel("calendar", {})).toBe("silent");
+  });
+
+  test("applies alias when channel resolves to silent", () => {
+    expect(
+      resolveOutputChannel("thalamus", { silentChannelAlias: "telegram" }),
+    ).toBe("telegram");
+  });
+
+  test("applies alias for explicit silent channel", () => {
+    expect(
+      resolveOutputChannel("silent", { silentChannelAlias: "telegram" }),
+    ).toBe("telegram");
+  });
+
+  test("does not apply alias for non-silent channels", () => {
+    expect(
+      resolveOutputChannel("telegram", { silentChannelAlias: "email" }),
+    ).toBe("telegram");
+  });
+});
+
+// --- createCombinedRegistry ---
+
+describe("createCombinedRegistry", () => {
+  test("merges built-in and skill tools", () => {
+    const builtin: BuiltinToolContext = { topicKey: "test-topic" };
+    const fakeBuiltin = {
+      definition: {
+        name: "my_tool",
+        description: "test",
+        inputSchema: {},
+        mutatesState: false,
+      },
+      async execute() {
+        return { ok: true as const, value: { content: "ok" } };
+      },
+    };
+
+    const combined = createCombinedRegistry(
+      [fakeBuiltin],
+      emptySkillRegistry(),
+      () => builtin,
+    );
+
+    expect(combined.tools).toHaveLength(1);
+    expect(combined.tools[0].name).toBe("my_tool");
+  });
+
+  test("dispatches to built-in tool by name", async () => {
+    const ctx: BuiltinToolContext = { topicKey: "test-topic" };
+    let receivedCtx: BuiltinToolContext | undefined;
+
+    const fakeBuiltin = {
+      definition: {
+        name: "my_tool",
+        description: "test",
+        inputSchema: {},
+        mutatesState: false,
+      },
+      async execute(_argsJson: string, c: BuiltinToolContext) {
+        receivedCtx = c;
+        return { ok: true as const, value: { content: "builtin-result" } };
+      },
+    };
+
+    const combined = createCombinedRegistry(
+      [fakeBuiltin],
+      emptySkillRegistry(),
+      () => ctx,
+    );
+
+    const result = await combined.executeTool("my_tool", "{}", {} as never);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.content).toBe("builtin-result");
+    }
+    expect(receivedCtx?.topicKey).toBe("test-topic");
+  });
+
+  test("reports built-in mutating state", () => {
+    const fakeBuiltin = {
+      definition: {
+        name: "mutating_tool",
+        description: "test",
+        inputSchema: {},
+        mutatesState: true,
+      },
+      async execute() {
+        return { ok: true as const, value: { content: "ok" } };
+      },
+    };
+
+    const combined = createCombinedRegistry(
+      [fakeBuiltin],
+      emptySkillRegistry(),
+      () => ({ topicKey: "" }),
+    );
+
+    expect(combined.isMutating("mutating_tool")).toBe(true);
+    expect(combined.isMutating("unknown")).toBe(false);
+  });
+});
+
+// --- send_message tool ---
+
+describe("send_message tool", () => {
+  beforeEach(() => {
+    initDatabase(":memory:");
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test("queues a message to a valid channel", async () => {
+    const channels = makeChannelRegistry({
+      name: "telegram",
+      canDeliver: true,
+    });
+    const tool = createSendMessageTool(channels);
+    const ctx: BuiltinToolContext = { topicKey: "trip-japan" };
+
+    const result = await tool.execute(
+      JSON.stringify({ channel: "telegram", text: "Hello!" }),
+      ctx,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.content).toContain("telegram");
+    }
+  });
+
+  test("rejects unknown channel", async () => {
+    const channels = makeChannelRegistry({
+      name: "telegram",
+      canDeliver: true,
+    });
+    const tool = createSendMessageTool(channels);
+    const ctx: BuiltinToolContext = { topicKey: "trip-japan" };
+
+    const result = await tool.execute(
+      JSON.stringify({ channel: "email", text: "Hello!" }),
+      ctx,
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects channel that cannot deliver", async () => {
+    const channels = makeChannelRegistry({
+      name: "calendar",
+      canDeliver: false,
+    });
+    const tool = createSendMessageTool(channels);
+    const ctx: BuiltinToolContext = { topicKey: "trip-japan" };
+
+    const result = await tool.execute(
+      JSON.stringify({ channel: "calendar", text: "Hello!" }),
+      ctx,
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects system channel (thalamus)", async () => {
+    const channels = makeChannelRegistry({
+      name: "telegram",
+      canDeliver: true,
+    });
+    const tool = createSendMessageTool(channels);
+    const ctx: BuiltinToolContext = { topicKey: "trip-japan" };
+
+    const result = await tool.execute(
+      JSON.stringify({ channel: "thalamus", text: "Routed!" }),
+      ctx,
+    );
+
+    // thalamus is not registered as a channel, so should fail
+    expect(result.ok).toBe(false);
+  });
+
+  test("requires channel argument", async () => {
+    const channels = makeChannelRegistry({
+      name: "telegram",
+      canDeliver: true,
+    });
+    const tool = createSendMessageTool(channels);
+
+    const result = await tool.execute(JSON.stringify({ text: "Hello!" }), {
+      topicKey: "test",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  test("requires text argument", async () => {
+    const channels = makeChannelRegistry({
+      name: "telegram",
+      canDeliver: true,
+    });
+    const tool = createSendMessageTool(channels);
+
+    const result = await tool.execute(JSON.stringify({ channel: "telegram" }), {
+      topicKey: "test",
+    });
+
+    expect(result.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds built-in tools architecture, system channel output routing, and Bun idleTimeout to prevent thalamus sync timeouts.

## Changes

### Built-in tools (`src/tools/`)
- `BuiltinTool` interface and `createCombinedRegistry()` that merges built-in tools with external skill registry
- `send_message` tool — validates target channel exists and can deliver, writes to outbox
- Built-in tools have no namespace prefix (vs `skillId.toolName` for external skills)
- `BuiltinToolContext` with mutable `topicKey` updated per message in the processing loop

### Output routing
- `resolveOutputChannel()` — system channels (thalamus, calendar) route to "silent" instead of echoing back
- `silentChannelAlias` config field — redirects "silent" → configured channel (e.g. "telegram") for early phases
- Applied in `loop.ts` outbox write path

### Fixes
- Thalamus idempotency key now includes `topicKey` to prevent cross-group dedup
- Bun `idleTimeout: 120` via `@shetty4l/core@0.1.33` passthrough — prevents /thalamus/sync timeout at default 10s
- `@shetty4l/core` bumped from `^0.1.30` to `^0.1.33`

## Tests
- 15 new tests in `test/tools.test.ts` (281 lines): resolveOutputChannel, createCombinedRegistry, send_message validation
- All 477 tests pass, 1583 expect() calls