### PR TITLE
fix: fallback to private chat for non-numeric Telegram topic keys

### DIFF
--- a/src/channels/telegram/index.ts
+++ b/src/channels/telegram/index.ts
@@ -261,11 +261,19 @@ export class TelegramChannel implements Channel {
 
         for (const message of messages) {
           try {
-            const topic = parseTelegramTopicKey(message.topicKey);
+            let topic = parseTelegramTopicKey(message.topicKey);
             if (!topic) {
-              throw new Error(
-                `Invalid telegram topic key: ${message.topicKey}`,
-              );
+              // TODO(topics): Temporary fallback — sends all non-Telegram topic keys
+              // to the user's private chat. Once topic management (cortex#66) is built
+              // out, resolve topic_key → telegram_thread_id via the topics table (which
+              // already has a telegram_thread_id column) before falling back here.
+              const fallbackUserId = this.config.telegramAllowedUserIds?.[0];
+              if (!fallbackUserId) {
+                throw new Error(
+                  `Cannot deliver: no fallback chat ID for topic "${message.topicKey}"`,
+                );
+              }
+              topic = { chatId: fallbackUserId };
             }
 
             const convertedText = formatForTelegram(message.text);

--- a/test/telegram-delivery.test.ts
+++ b/test/telegram-delivery.test.ts
@@ -283,4 +283,62 @@ describe("telegram delivery loop", () => {
     expect(row!.status).toBe("leased");
     expect(row!.attempts).toBeGreaterThanOrEqual(1);
   });
+
+  test("delivers to fallback private chat for non-numeric topic keys", async () => {
+    const messageId = enqueueOutboxMessage({
+      channel: "telegram",
+      topicKey: "manchester-united-football-matches",
+      text: "Upcoming match tomorrow",
+    });
+
+    const requests: Array<Record<string, unknown>> = [];
+    globalThis.fetch = withGetUpdatesStub(async (_url, init) => {
+      const payload = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      requests.push(payload);
+      return Response.json({
+        ok: true,
+        result: { message_id: 1, date: 1700000000, chat: { id: 6052033650 } },
+      });
+    });
+
+    const loop = startTelegramDeliveryLoop(
+      testConfig({ telegramAllowedUserIds: [6052033650] }),
+      { maxBatch: 1, onErrorDelayMs: 1, onEmptyDelayMs: 1 },
+    );
+
+    await waitFor(() => getOutboxMessage(messageId)?.status === "delivered");
+    await loop.stop();
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].chat_id).toBe(6052033650);
+    expect(requests[0].message_thread_id).toBeUndefined();
+  });
+
+  test("fails delivery when no fallback user ID and non-numeric topic key", async () => {
+    const messageId = enqueueOutboxMessage({
+      channel: "telegram",
+      topicKey: "some-semantic-topic",
+      text: "This should fail",
+    });
+
+    globalThis.fetch = withGetUpdatesStub(async () => {
+      return Response.json({
+        ok: true,
+        result: { message_id: 1, date: 1700000000, chat: { id: 1 } },
+      });
+    });
+
+    const loop = startTelegramDeliveryLoop(
+      testConfig({ telegramAllowedUserIds: [] }),
+      { maxBatch: 1, onErrorDelayMs: 1, onEmptyDelayMs: 1 },
+    );
+
+    // Wait briefly — message should NOT be delivered (no fallback)
+    await Bun.sleep(100);
+    await loop.stop();
+
+    const row = getOutboxMessage(messageId);
+    expect(row).not.toBeNull();
+    expect(row!.status).not.toBe("delivered");
+  });
 });


### PR DESCRIPTION
## Summary

When thalamus-created semantic topic keys (e.g. `trip-planning`) can't be parsed as numeric Telegram `chatId[:threadId]`, fall back to delivering in the user's private chat via `telegramAllowedUserIds[0]` instead of throwing.

<!-- TODO(topics): temporary — resolve topic_key → telegram_thread_id via topics table when cortex#66 is built out -->

## Changes

- `src/channels/telegram/index.ts`: Replace hard error with fallback to first allowed user's private chat. Large TODO comment for proper topic→thread mapping.
- `test/telegram-delivery.test.ts`: 2 new tests — fallback delivery + error when no fallback available.

## Tests
479 pass, 1588 expect() calls