### PR TITLE
feat: add GET /stats endpoint for Wave 3 stats API

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -35,6 +35,7 @@ const SCHEMA = `
     attempts INTEGER NOT NULL DEFAULT 0,
     next_attempt_at INTEGER NOT NULL DEFAULT 0,
     error TEXT,
+    processing_ms INTEGER,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL,
     -- Dedup is on (channel, external_message_id), NOT idempotency_key.
@@ -172,6 +173,15 @@ const dbManager = createDatabaseManager({
 
 const log = createLogger("cortex");
 
+// --- Migration helpers ---
+
+function hasColumn(database: Database, table: string, column: string): boolean {
+  const tableInfo = database.prepare(`PRAGMA table_info(${table})`).all() as {
+    name: string;
+  }[];
+  return tableInfo.some((col) => col.name === column);
+}
+
 /**
  * Initialize the database. Returns the Database instance on success.
  * Idempotent — returns existing instance if already open.
@@ -186,6 +196,11 @@ export function initDatabase(pathOverride?: string): Result<Database> {
     const db = dbManager.init(pathOverride);
     // Enable foreign keys (core sets WAL mode already)
     db.exec("PRAGMA foreign_keys = ON");
+
+    // Migration: add processing_ms column (Wave 3: stats API)
+    if (!hasColumn(db, "inbox_messages", "processing_ms")) {
+      db.exec("ALTER TABLE inbox_messages ADD COLUMN processing_ms INTEGER");
+    }
 
     // Recover inbox messages left in 'processing' from a prior crash.
     // Safe because the processing loop hasn't started yet at this point.
@@ -364,18 +379,29 @@ export function claimNextInboxMessage(): InboxMessage | null {
 
 /**
  * Mark an inbox message as done (or failed with an error reason).
+ * Optionally records the processing time in milliseconds.
  */
-export function completeInboxMessage(id: string, error?: string): void {
+export function completeInboxMessage(
+  id: string,
+  processingMs?: number,
+  error?: string,
+): void {
   const database = getDatabase();
   const now = Date.now();
   const status = error ? "failed" : "done";
 
   const stmt = database.prepare(`
     UPDATE inbox_messages
-    SET status = $status, error = $error, updated_at = $now
+    SET status = $status, error = $error, processing_ms = $processingMs, updated_at = $now
     WHERE id = $id
   `);
-  stmt.run({ $id: id, $status: status, $error: error ?? null, $now: now });
+  stmt.run({
+    $id: id,
+    $status: status,
+    $error: error ?? null,
+    $processingMs: processingMs ?? null,
+    $now: now,
+  });
 }
 
 /**
@@ -1168,4 +1194,137 @@ export function deleteProcessedBuffers(ids: string[]): number {
     .run(params);
 
   return result.changes;
+}
+
+// --- Stats API (Wave 3) ---
+
+export interface CortexStats {
+  inbox: {
+    pending: number;
+    processing: number;
+    done_1h: number;
+    failed_1h: number;
+  };
+  outbox: {
+    pending: number;
+    delivered_1h: number;
+    dead_total: number;
+  };
+  receptors: {
+    calendar_last_sync_at: number | null;
+    calendar_buffer_pending: number;
+    thalamus_last_sync_at: number | null;
+  };
+  processing: {
+    p50_ms: number | null;
+    p95_ms: number | null;
+    p99_ms: number | null;
+  };
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+/**
+ * Get aggregated stats for the /stats API endpoint.
+ * Returns inbox/outbox counts, receptor sync timestamps, and processing latency percentiles.
+ * Time-based metrics use a 1-hour sliding window.
+ */
+export function getStats(): CortexStats {
+  const database = getDatabase();
+  const oneHourAgo = Date.now() - 3_600_000;
+
+  // Inbox stats: pending/processing (all time) + done/failed (last hour)
+  const inboxRows = database
+    .prepare(
+      `
+      SELECT status, COUNT(*) as count FROM inbox_messages
+      WHERE status IN ('pending', 'processing')
+         OR (status IN ('done', 'failed') AND updated_at > $oneHourAgo)
+      GROUP BY status
+    `,
+    )
+    .all({ $oneHourAgo: oneHourAgo }) as { status: string; count: number }[];
+
+  const inboxByStatus = Object.fromEntries(
+    inboxRows.map((r) => [r.status, r.count]),
+  );
+
+  // Outbox stats: pending (all time) + delivered (last hour) + dead (all time)
+  const outboxRows = database
+    .prepare(
+      `
+      SELECT status, COUNT(*) as count FROM outbox_messages
+      WHERE status = 'pending'
+         OR (status = 'delivered' AND updated_at > $oneHourAgo)
+         OR status = 'dead'
+      GROUP BY status
+    `,
+    )
+    .all({ $oneHourAgo: oneHourAgo }) as { status: string; count: number }[];
+
+  const outboxByStatus = Object.fromEntries(
+    outboxRows.map((r) => [r.status, r.count]),
+  );
+
+  // Receptor cursors (last sync timestamps)
+  const cursorRows = database
+    .prepare(`SELECT channel, last_synced_at FROM receptor_cursors`)
+    .all() as { channel: string; last_synced_at: number }[];
+
+  const cursorByChannel = Object.fromEntries(
+    cursorRows.map((r) => [r.channel, r.last_synced_at]),
+  );
+
+  // Receptor buffers pending (count per channel)
+  const bufferRows = database
+    .prepare(
+      `SELECT channel, COUNT(*) as count FROM receptor_buffers GROUP BY channel`,
+    )
+    .all() as { channel: string; count: number }[];
+
+  const bufferByChannel = Object.fromEntries(
+    bufferRows.map((r) => [r.channel, r.count]),
+  );
+
+  // Processing latencies (p50, p95, p99) from done messages in last hour
+  const latencyRows = database
+    .prepare(
+      `
+      SELECT processing_ms FROM inbox_messages
+      WHERE status = 'done' AND updated_at > $oneHourAgo AND processing_ms IS NOT NULL
+      ORDER BY processing_ms
+    `,
+    )
+    .all({ $oneHourAgo: oneHourAgo }) as { processing_ms: number }[];
+
+  const latencies = latencyRows.map((r) => r.processing_ms);
+  const hasLatency = latencies.length > 0;
+
+  return {
+    inbox: {
+      pending: inboxByStatus.pending ?? 0,
+      processing: inboxByStatus.processing ?? 0,
+      done_1h: inboxByStatus.done ?? 0,
+      failed_1h: inboxByStatus.failed ?? 0,
+    },
+    outbox: {
+      pending: outboxByStatus.pending ?? 0,
+      delivered_1h: outboxByStatus.delivered ?? 0,
+      dead_total: outboxByStatus.dead ?? 0,
+    },
+    receptors: {
+      calendar_last_sync_at: cursorByChannel.calendar ?? null,
+      calendar_buffer_pending: bufferByChannel.calendar ?? 0,
+      thalamus_last_sync_at: cursorByChannel.thalamus ?? null,
+    },
+    processing: {
+      p50_ms: hasLatency ? percentile(latencies, 50) : null,
+      p95_ms: hasLatency ? percentile(latencies, 95) : null,
+      p99_ms: hasLatency ? percentile(latencies, 99) : null,
+    },
+  };
 }

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -237,6 +237,7 @@ export function startProcessingLoop(
           }
 
           const elapsed = ((performance.now() - startMs) / 1000).toFixed(1);
+          const processingMs = Math.round(performance.now() - startMs);
 
           if (ok) {
             // 7. Trigger async extraction (fire-and-forget, serialized per topic)
@@ -263,7 +264,7 @@ export function startProcessingLoop(
               text: responseText,
             });
 
-            completeInboxMessage(message.id);
+            completeInboxMessage(message.id, processingMs);
 
             const responsePreview =
               responseText.length > 120
@@ -282,7 +283,7 @@ export function startProcessingLoop(
                 errorMsg!,
               );
             } else {
-              completeInboxMessage(message.id, errorMsg);
+              completeInboxMessage(message.id, processingMs, errorMsg);
             }
           }
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@
  *
  * Routes:
  *   GET  /health         — health check (handled by core)
+ *   GET  /stats          — aggregated stats (Wave 3)
  *   POST /ingest         — DEPRECATED (returns 410 Gone)
  *   POST /receive        — thalamus-gated event ingress
  *   POST /outbox/poll    — connector delivery claim
@@ -19,7 +20,7 @@ import {
 import { createLogger } from "@shetty4l/core/log";
 import { timingSafeEqual } from "crypto";
 import type { CortexConfig } from "./config";
-import { ackOutboxMessage, pollOutboxMessages } from "./db";
+import { ackOutboxMessage, getStats, pollOutboxMessages } from "./db";
 import type { Thalamus } from "./thalamus";
 import { VERSION } from "./version";
 
@@ -356,7 +357,9 @@ export function startServer(
       const start = performance.now();
       let response: Response | null = null;
 
-      if (req.method === "POST" && url.pathname === "/ingest") {
+      if (req.method === "GET" && url.pathname === "/stats") {
+        response = jsonOk(getStats());
+      } else if (req.method === "POST" && url.pathname === "/ingest") {
         response = handleIngestDeprecated();
       } else if (req.method === "POST" && url.pathname === "/receive") {
         if (!thalamus) {

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -1,0 +1,331 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import type { CortexConfig } from "../src/config";
+import {
+  type CortexStats,
+  closeDatabase,
+  completeInboxMessage,
+  enqueueInboxMessage,
+  enqueueOutboxMessage,
+  getDatabase,
+  getStats,
+  initDatabase,
+  insertReceptorBuffer,
+  resetDatabase,
+  upsertReceptorCursor,
+} from "../src/db";
+import { startServer } from "../src/server";
+
+const API_KEY = "test-stats-key";
+
+function makeConfig(): CortexConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    ingestApiKey: API_KEY,
+    models: ["test-model"],
+    synapseUrl: "http://localhost:7750",
+    engramUrl: "http://localhost:7749",
+    activeWindowSize: 10,
+    extractionInterval: 3,
+    turnTtlDays: 30,
+    schedulerTickSeconds: 30,
+    schedulerTimezone: "UTC",
+    outboxPollDefaultBatch: 20,
+    outboxLeaseSeconds: 60,
+    outboxMaxAttempts: 10,
+    inboxMaxAttempts: 5,
+    skillDirs: [],
+    skillConfig: {},
+    toolTimeoutMs: 20000,
+    maxToolRounds: 8,
+    synapseTimeoutMs: 60_000,
+    thalamusModels: ["test-model"],
+    thalamusSyncIntervalMs: 21_600_000,
+  };
+}
+
+describe("stats API", () => {
+  beforeEach(() => {
+    resetDatabase();
+    initDatabase(":memory:");
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  describe("getStats()", () => {
+    test("returns zeros/nulls for empty database", () => {
+      const stats = getStats();
+
+      // Inbox
+      expect(stats.inbox.pending).toBe(0);
+      expect(stats.inbox.processing).toBe(0);
+      expect(stats.inbox.done_1h).toBe(0);
+      expect(stats.inbox.failed_1h).toBe(0);
+
+      // Outbox
+      expect(stats.outbox.pending).toBe(0);
+      expect(stats.outbox.delivered_1h).toBe(0);
+      expect(stats.outbox.dead_total).toBe(0);
+
+      // Receptors
+      expect(stats.receptors.calendar_last_sync_at).toBeNull();
+      expect(stats.receptors.calendar_buffer_pending).toBe(0);
+      expect(stats.receptors.thalamus_last_sync_at).toBeNull();
+
+      // Processing latencies
+      expect(stats.processing.p50_ms).toBeNull();
+      expect(stats.processing.p95_ms).toBeNull();
+      expect(stats.processing.p99_ms).toBeNull();
+    });
+
+    test("counts inbox messages by status", () => {
+      // Create some inbox messages
+      enqueueInboxMessage({
+        channel: "telegram",
+        externalMessageId: "msg1",
+        topicKey: "topic:1",
+        userId: "user1",
+        text: "Hello",
+        occurredAt: Date.now(),
+        idempotencyKey: "key1",
+        priority: 5,
+      });
+      enqueueInboxMessage({
+        channel: "telegram",
+        externalMessageId: "msg2",
+        topicKey: "topic:1",
+        userId: "user1",
+        text: "Hello again",
+        occurredAt: Date.now(),
+        idempotencyKey: "key2",
+        priority: 5,
+      });
+
+      const stats = getStats();
+      expect(stats.inbox.pending).toBe(2);
+    });
+
+    test("counts done messages in last hour", () => {
+      // Create and complete a message
+      const result = enqueueInboxMessage({
+        channel: "telegram",
+        externalMessageId: "msg1",
+        topicKey: "topic:1",
+        userId: "user1",
+        text: "Hello",
+        occurredAt: Date.now(),
+        idempotencyKey: "key1",
+        priority: 5,
+      });
+      completeInboxMessage(result.eventId, 500);
+
+      const stats = getStats();
+      expect(stats.inbox.done_1h).toBe(1);
+      expect(stats.inbox.pending).toBe(0);
+    });
+
+    test("counts failed messages in last hour", () => {
+      const result = enqueueInboxMessage({
+        channel: "telegram",
+        externalMessageId: "msg1",
+        topicKey: "topic:1",
+        userId: "user1",
+        text: "Hello",
+        occurredAt: Date.now(),
+        idempotencyKey: "key1",
+        priority: 5,
+      });
+      completeInboxMessage(result.eventId, 100, "some error");
+
+      const stats = getStats();
+      expect(stats.inbox.failed_1h).toBe(1);
+    });
+
+    test("excludes old done/failed messages from 1h counts", () => {
+      // Manually insert a message with old updated_at
+      const db = getDatabase();
+      const twoHoursAgo = Date.now() - 2 * 3600 * 1000;
+      db.prepare(`
+        INSERT INTO inbox_messages
+        (id, channel, external_message_id, topic_key, user_id, text, occurred_at,
+         idempotency_key, priority, status, attempts, next_attempt_at, created_at, updated_at)
+        VALUES
+        ('old_done', 'telegram', 'old1', 'topic:1', 'user1', 'test', $now,
+         'key_old', 5, 'done', 0, 0, $twoHoursAgo, $twoHoursAgo)
+      `).run({ $now: Date.now(), $twoHoursAgo: twoHoursAgo });
+
+      const stats = getStats();
+      expect(stats.inbox.done_1h).toBe(0); // Old message not counted
+    });
+
+    test("counts outbox messages by status", () => {
+      enqueueOutboxMessage({
+        channel: "telegram",
+        topicKey: "topic:1",
+        text: "Response 1",
+      });
+      enqueueOutboxMessage({
+        channel: "telegram",
+        topicKey: "topic:1",
+        text: "Response 2",
+      });
+
+      const stats = getStats();
+      expect(stats.outbox.pending).toBe(2);
+    });
+
+    test("reports receptor cursor timestamps", () => {
+      upsertReceptorCursor("calendar", "cursor-value-1");
+
+      const stats = getStats();
+      // last_synced_at is set to Date.now() by the function
+      expect(stats.receptors.calendar_last_sync_at).not.toBeNull();
+      expect(typeof stats.receptors.calendar_last_sync_at).toBe("number");
+    });
+
+    test("counts pending receptor buffers", () => {
+      insertReceptorBuffer({
+        channel: "calendar",
+        externalId: "event-1",
+        content: "Event content 1",
+        occurredAt: Date.now(),
+      });
+      insertReceptorBuffer({
+        channel: "calendar",
+        externalId: "event-2",
+        content: "Event content 2",
+        occurredAt: Date.now(),
+      });
+
+      const stats = getStats();
+      expect(stats.receptors.calendar_buffer_pending).toBe(2);
+    });
+
+    test("computes processing latency percentiles", () => {
+      // Create 10 messages with different processing times
+      for (let i = 1; i <= 10; i++) {
+        const result = enqueueInboxMessage({
+          channel: "telegram",
+          externalMessageId: `msg${i}`,
+          topicKey: "topic:1",
+          userId: "user1",
+          text: `Message ${i}`,
+          occurredAt: Date.now(),
+          idempotencyKey: `key${i}`,
+          priority: 5,
+        });
+        // Processing times: 100, 200, 300, ..., 1000
+        completeInboxMessage(result.eventId, i * 100);
+      }
+
+      const stats = getStats();
+      // p50 = 5th value = 500ms
+      expect(stats.processing.p50_ms).toBe(500);
+      // p95 = 10th value = 1000ms
+      expect(stats.processing.p95_ms).toBe(1000);
+      // p99 = 10th value = 1000ms
+      expect(stats.processing.p99_ms).toBe(1000);
+    });
+
+    test("returns null percentiles when no processing data", () => {
+      // Create a message but don't complete it
+      enqueueInboxMessage({
+        channel: "telegram",
+        externalMessageId: "msg1",
+        topicKey: "topic:1",
+        userId: "user1",
+        text: "Hello",
+        occurredAt: Date.now(),
+        idempotencyKey: "key1",
+        priority: 5,
+      });
+
+      const stats = getStats();
+      expect(stats.processing.p50_ms).toBeNull();
+      expect(stats.processing.p95_ms).toBeNull();
+      expect(stats.processing.p99_ms).toBeNull();
+    });
+  });
+
+  describe("GET /stats endpoint", () => {
+    let server: { port: number; stop: () => void };
+    let baseUrl: string;
+
+    beforeAll(() => {
+      resetDatabase();
+      initDatabase(":memory:");
+      server = startServer(makeConfig());
+      baseUrl = `http://localhost:${server.port}`;
+    });
+
+    afterAll(() => {
+      server.stop();
+      closeDatabase();
+    });
+
+    test("returns 200 with correct shape", async () => {
+      const response = await fetch(`${baseUrl}/stats`);
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as CortexStats;
+
+      // Verify shape
+      expect(data).toHaveProperty("inbox");
+      expect(data).toHaveProperty("outbox");
+      expect(data).toHaveProperty("receptors");
+      expect(data).toHaveProperty("processing");
+
+      // Inbox shape
+      expect(typeof data.inbox.pending).toBe("number");
+      expect(typeof data.inbox.processing).toBe("number");
+      expect(typeof data.inbox.done_1h).toBe("number");
+      expect(typeof data.inbox.failed_1h).toBe("number");
+
+      // Outbox shape
+      expect(typeof data.outbox.pending).toBe("number");
+      expect(typeof data.outbox.delivered_1h).toBe("number");
+      expect(typeof data.outbox.dead_total).toBe("number");
+
+      // Receptors shape
+      expect(
+        data.receptors.calendar_last_sync_at === null ||
+          typeof data.receptors.calendar_last_sync_at === "number",
+      ).toBe(true);
+      expect(typeof data.receptors.calendar_buffer_pending).toBe("number");
+      expect(
+        data.receptors.thalamus_last_sync_at === null ||
+          typeof data.receptors.thalamus_last_sync_at === "number",
+      ).toBe(true);
+
+      // Processing shape
+      expect(
+        data.processing.p50_ms === null ||
+          typeof data.processing.p50_ms === "number",
+      ).toBe(true);
+      expect(
+        data.processing.p95_ms === null ||
+          typeof data.processing.p95_ms === "number",
+      ).toBe(true);
+      expect(
+        data.processing.p99_ms === null ||
+          typeof data.processing.p99_ms === "number",
+      ).toBe(true);
+    });
+
+    test("does not require authentication", async () => {
+      // No auth header — should still work
+      const response = await fetch(`${baseUrl}/stats`);
+      expect(response.status).toBe(200);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `processing_ms` column to `inbox_messages` with migration for existing databases
- Update `completeInboxMessage()` to record processing latency
- Add `getStats()` function with aggregated stats queries
- Add GET `/stats` route (no auth, matches `/health` pattern)
- Add comprehensive test suite (12 test cases)

## Response Shape
```json
{
  "inbox": { "pending": 0, "processing": 0, "done_1h": 0, "failed_1h": 0 },
  "outbox": { "pending": 0, "delivered_1h": 0, "dead_total": 0 },
  "receptors": { 
    "calendar_last_sync_at": null, 
    "calendar_buffer_pending": 0, 
    "thalamus_last_sync_at": null 
  },
  "processing": { "p50_ms": null, "p95_ms": null, "p99_ms": null }
}
```

## Wave 3 Context
This completes Wave 3 (Stats APIs):
- engram: PR #42 (merged)
- synapse: PR #24 (merged)  
- **cortex: this PR**

Wave 4 (Wilson aggregation + dashboard) is now unblocked.

## Changes
| File | Changes |
|------|---------|
| `src/db.ts` | +165 lines: schema, migration, `completeInboxMessage()` update, `getStats()` |
| `src/loop.ts` | +3 lines: compute and pass `processingMs` |
| `src/server.ts` | +5 lines: GET `/stats` route |
| `test/stats.test.ts` | NEW: 12 tests |

## Testing
- 517 tests pass
- Types, lint, format all green