### PR TITLE
fix: thalamus_last_sync_at → thalamus_last_run_at in /stats

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1213,7 +1213,7 @@ export interface CortexStats {
   receptors: {
     calendar_last_sync_at: number | null;
     calendar_buffer_pending: number;
-    thalamus_last_sync_at: number | null;
+    thalamus_last_run_at: number | null;
   };
   processing: {
     p50_ms: number | null;
@@ -1228,12 +1228,17 @@ function percentile(sorted: number[], p: number): number {
   return sorted[Math.max(0, idx)];
 }
 
+/** Minimal interface for thalamus dependency in getStats(). */
+interface ThalamusSyncInfo {
+  getLastSyncAt(): number | null;
+}
+
 /**
  * Get aggregated stats for the /stats API endpoint.
  * Returns inbox/outbox counts, receptor sync timestamps, and processing latency percentiles.
  * Time-based metrics use a 1-hour sliding window.
  */
-export function getStats(): CortexStats {
+export function getStats(thalamus?: ThalamusSyncInfo): CortexStats {
   const database = getDatabase();
   const oneHourAgo = Date.now() - 3_600_000;
 
@@ -1319,7 +1324,7 @@ export function getStats(): CortexStats {
     receptors: {
       calendar_last_sync_at: cursorByChannel.calendar ?? null,
       calendar_buffer_pending: bufferByChannel.calendar ?? 0,
-      thalamus_last_sync_at: cursorByChannel.thalamus ?? null,
+      thalamus_last_run_at: thalamus?.getLastSyncAt() ?? null,
     },
     processing: {
       p50_ms: hasLatency ? percentile(latencies, 50) : null,

--- a/src/server.ts
+++ b/src/server.ts
@@ -358,7 +358,7 @@ export function startServer(
       let response: Response | null = null;
 
       if (req.method === "GET" && url.pathname === "/stats") {
-        response = jsonOk(getStats());
+        response = jsonOk(getStats(thalamus));
       } else if (req.method === "POST" && url.pathname === "/ingest") {
         response = handleIngestDeprecated();
       } else if (req.method === "POST" && url.pathname === "/receive") {

--- a/src/thalamus/index.ts
+++ b/src/thalamus/index.ts
@@ -67,8 +67,14 @@ export interface SyncResult {
 
 export class Thalamus {
   private syncTimer: ReturnType<typeof setInterval> | null = null;
+  private lastSyncAt: number | null = null;
 
   constructor(private config?: ThalamusConfig) {}
+
+  /** Returns the timestamp of the last syncAll() run, or null if never run. */
+  getLastSyncAt(): number | null {
+    return this.lastSyncAt;
+  }
 
   async start(): Promise<void> {
     if (!this.config) {
@@ -91,6 +97,8 @@ export class Thalamus {
   }
 
   async syncAll(): Promise<SyncResult> {
+    this.lastSyncAt = Date.now();
+
     if (!this.config) {
       log("thalamus syncAll: no config, skipping");
       return { ok: true, groups: 0, buffers: 0 };

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -80,12 +80,26 @@ describe("stats API", () => {
       // Receptors
       expect(stats.receptors.calendar_last_sync_at).toBeNull();
       expect(stats.receptors.calendar_buffer_pending).toBe(0);
-      expect(stats.receptors.thalamus_last_sync_at).toBeNull();
+      expect(stats.receptors.thalamus_last_run_at).toBeNull();
 
       // Processing latencies
       expect(stats.processing.p50_ms).toBeNull();
       expect(stats.processing.p95_ms).toBeNull();
       expect(stats.processing.p99_ms).toBeNull();
+    });
+
+    test("includes thalamus_last_run_at when thalamus provided", () => {
+      const mockThalamus = {
+        getLastSyncAt: () => 1234567890,
+      };
+
+      const stats = getStats(mockThalamus);
+      expect(stats.receptors.thalamus_last_run_at).toBe(1234567890);
+    });
+
+    test("thalamus_last_run_at is null when thalamus not provided", () => {
+      const stats = getStats();
+      expect(stats.receptors.thalamus_last_run_at).toBeNull();
     });
 
     test("counts inbox messages by status", () => {
@@ -303,8 +317,8 @@ describe("stats API", () => {
       ).toBe(true);
       expect(typeof data.receptors.calendar_buffer_pending).toBe("number");
       expect(
-        data.receptors.thalamus_last_sync_at === null ||
-          typeof data.receptors.thalamus_last_sync_at === "number",
+        data.receptors.thalamus_last_run_at === null ||
+          typeof data.receptors.thalamus_last_run_at === "number",
       ).toBe(true);
 
       // Processing shape


### PR DESCRIPTION
## Summary

- Rename `thalamus_last_sync_at` → `thalamus_last_run_at` (more accurate name)
- Track when `syncAll()` is called via in-memory timestamp instead of looking for non-existent "thalamus" cursor
- Pass Thalamus instance to `getStats()` using minimal interface to avoid circular imports

## Context

The field was always `null` because thalamus isn't a channel—it's a processor that writes per-channel cursors (e.g., "calendar"). The fix tracks when thalamus actually runs for operational health monitoring.

Companion to Wilson PR #31 which updated the dashboard indicators.

## Files Changed

- `src/thalamus/index.ts` - Added `lastSyncAt` property and `getLastSyncAt()` getter
- `src/db.ts` - Added `ThalamusSyncInfo` interface, updated `getStats()` signature
- `src/server.ts` - Pass thalamus instance to `getStats()`
- `test/stats.test.ts` - Updated field references, added 2 new tests

## Testing

All 519 tests pass with 1684 assertions.