### PR TITLE
fix(thalamus): distinguish parse failure from empty valid response

### DIFF
--- a/src/thalamus/index.ts
+++ b/src/thalamus/index.ts
@@ -12,7 +12,9 @@ import { listTopics } from "../topics";
 import { formatChannelData } from "./formatters";
 import {
   buildTriageUserPrompt,
+  type ParseResult,
   parseSyncOutput,
+  THALAMUS_RETRY_PROMPT,
   THALAMUS_TRIAGE_SYSTEM_PROMPT,
 } from "./prompts";
 
@@ -194,8 +196,42 @@ export class Thalamus {
       throw new Error(chatResult.error);
     }
 
-    const messageContent = chatResult.value.content;
-    const items = parseSyncOutput(messageContent);
+    let messageContent = chatResult.value.content;
+    let parseResult: ParseResult = parseSyncOutput(messageContent);
+
+    // Retry with correction prompt if parse failed (not just empty items)
+    if (!parseResult.ok && buffers.length > 0) {
+      log("thalamus sync: parse failed, retrying with correction prompt");
+
+      const retryResult = await chat(
+        [
+          { role: "system", content: THALAMUS_TRIAGE_SYSTEM_PROMPT },
+          { role: "user", content: userPrompt },
+          { role: "assistant", content: messageContent },
+          { role: "user", content: THALAMUS_RETRY_PROMPT },
+        ],
+        config.thalamusModels,
+        config.synapseUrl,
+        { temperature: 0.1, timeoutMs: config.synapseTimeoutMs },
+      );
+
+      if (retryResult.ok) {
+        messageContent = retryResult.value.content;
+        parseResult = parseSyncOutput(messageContent);
+      } else {
+        log(`thalamus sync: retry failed: ${retryResult.error}`);
+      }
+    }
+
+    // Prevent data loss: only delete buffers if parsing succeeded
+    if (!parseResult.ok && buffers.length > 0) {
+      log(
+        `thalamus sync: all attempts failed, preserving ${buffers.length} buffers for next sync`,
+      );
+      return 0;
+    }
+
+    const items = parseResult.items;
 
     // Create inbox messages for each triaged group
     for (const item of items) {

--- a/src/thalamus/prompts.ts
+++ b/src/thalamus/prompts.ts
@@ -19,9 +19,18 @@ export interface SyncOutputItem {
   rawBufferIds: string[];
 }
 
+export interface ParseResult {
+  /** True if the LLM response was valid JSON with an items array */
+  ok: boolean;
+  /** Parsed items (empty array if ok=true but nothing noteworthy, or if ok=false) */
+  items: SyncOutputItem[];
+}
+
 // --- Prompts ---
 
 export const THALAMUS_TRIAGE_SYSTEM_PROMPT = `You are a triage layer for incoming sensor data in a personal life assistant.
+
+CRITICAL: You must respond with valid JSON only. No markdown, no explanation, no code fences. Start your response with { and end with }.
 
 Your job:
 1. Review buffered data from various channels (calendar, email, etc.)
@@ -58,6 +67,13 @@ Output ONLY valid JSON matching this schema:
 }
 
 Do not include any text outside the JSON.`;
+
+/**
+ * Correction prompt used when the LLM returns invalid JSON.
+ * Appended to the conversation to request a clean retry.
+ */
+export const THALAMUS_RETRY_PROMPT =
+  "Your response was not valid JSON. Respond with ONLY the JSON object. No markdown, no explanation, no code fences. Start with { and end with }.";
 
 export function buildTriageUserPrompt(
   buffers: {
@@ -96,7 +112,7 @@ export function buildTriageUserPrompt(
 
 // --- Parsing ---
 
-export function parseSyncOutput(llmResponse: string): SyncOutputItem[] {
+export function parseSyncOutput(llmResponse: string): ParseResult {
   try {
     // Strip markdown code fences if present
     let json = llmResponse.trim();
@@ -109,7 +125,7 @@ export function parseSyncOutput(llmResponse: string): SyncOutputItem[] {
 
     if (!parsed.items || !Array.isArray(parsed.items)) {
       log("thalamus sync: parsed response missing items array");
-      return [];
+      return { ok: false, items: [] };
     }
 
     const valid: SyncOutputItem[] = [];
@@ -128,11 +144,11 @@ export function parseSyncOutput(llmResponse: string): SyncOutputItem[] {
       }
     }
 
-    return valid;
+    return { ok: true, items: valid };
   } catch (e) {
     log(
       `thalamus sync: failed to parse LLM response: ${e instanceof Error ? e.message : String(e)}`,
     );
-    return [];
+    return { ok: false, items: [] };
   }
 }

--- a/test/thalamus-prompts.test.ts
+++ b/test/thalamus-prompts.test.ts
@@ -143,11 +143,12 @@ describe("parseSyncOutput", () => {
     });
 
     const result = parseSyncOutput(input);
-    expect(result).toHaveLength(1);
-    expect(result[0].topicKey).toBe("japan-trip");
-    expect(result[0].priority).toBe(2);
-    expect(result[0].summary).toBe("3 upcoming events for Japan trip");
-    expect(result[0].rawBufferIds).toEqual(["rb_1", "rb_2"]);
+    expect(result.ok).toBe(true);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].topicKey).toBe("japan-trip");
+    expect(result.items[0].priority).toBe(2);
+    expect(result.items[0].summary).toBe("3 upcoming events for Japan trip");
+    expect(result.items[0].rawBufferIds).toEqual(["rb_1", "rb_2"]);
   });
 
   test("handles markdown code fences", () => {
@@ -165,8 +166,9 @@ describe("parseSyncOutput", () => {
 \`\`\``;
 
     const result = parseSyncOutput(input);
-    expect(result).toHaveLength(1);
-    expect(result[0].topicKey).toBe("work");
+    expect(result.ok).toBe(true);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].topicKey).toBe("work");
   });
 
   test("handles code fences without language tag", () => {
@@ -175,22 +177,26 @@ describe("parseSyncOutput", () => {
 \`\`\``;
 
     const result = parseSyncOutput(input);
-    expect(result).toHaveLength(1);
+    expect(result.ok).toBe(true);
+    expect(result.items).toHaveLength(1);
   });
 
-  test("returns empty array on invalid JSON", () => {
+  test("returns ok=false on invalid JSON", () => {
     const result = parseSyncOutput("this is not json at all");
-    expect(result).toEqual([]);
+    expect(result.ok).toBe(false);
+    expect(result.items).toEqual([]);
   });
 
-  test("returns empty array when items is missing", () => {
+  test("returns ok=false when items is missing", () => {
     const result = parseSyncOutput('{"data": []}');
-    expect(result).toEqual([]);
+    expect(result.ok).toBe(false);
+    expect(result.items).toEqual([]);
   });
 
-  test("returns empty array when items is not an array", () => {
+  test("returns ok=false when items is not an array", () => {
     const result = parseSyncOutput('{"items": "not-array"}');
-    expect(result).toEqual([]);
+    expect(result.ok).toBe(false);
+    expect(result.items).toEqual([]);
   });
 
   test("validates item structure — skips invalid items", () => {
@@ -209,13 +215,15 @@ describe("parseSyncOutput", () => {
     });
 
     const result = parseSyncOutput(input);
-    expect(result).toHaveLength(1);
-    expect(result[0].topicKey).toBe("valid");
+    expect(result.ok).toBe(true);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].topicKey).toBe("valid");
   });
 
-  test("returns empty items array from valid empty response", () => {
+  test("returns ok=true with empty items array from valid empty response", () => {
     const result = parseSyncOutput('{"items":[]}');
-    expect(result).toEqual([]);
+    expect(result.ok).toBe(true);
+    expect(result.items).toEqual([]);
   });
 
   test("parses multiple items", () => {
@@ -237,8 +245,9 @@ describe("parseSyncOutput", () => {
     });
 
     const result = parseSyncOutput(input);
-    expect(result).toHaveLength(2);
-    expect(result[0].topicKey).toBe("a");
-    expect(result[1].topicKey).toBe("b");
+    expect(result.ok).toBe(true);
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].topicKey).toBe("a");
+    expect(result.items[1].topicKey).toBe("b");
   });
 });

--- a/test/thalamus.test.ts
+++ b/test/thalamus.test.ts
@@ -572,6 +572,201 @@ describe("thalamus.syncAll()", () => {
     const remaining = getUnprocessedBuffers();
     expect(remaining).toHaveLength(0);
   });
+
+  test("retries with correction prompt on parse failure", async () => {
+    insertReceptorBuffer({
+      channel: "calendar",
+      externalId: "cal-1",
+      content: "Meeting tomorrow",
+      occurredAt: Date.now(),
+    });
+
+    let callCount = 0;
+    mockSynapseHandler = () => {
+      callCount++;
+      if (callCount === 1) {
+        // First call: return invalid JSON (markdown)
+        return Response.json({
+          id: "chat-test",
+          object: "chat.completion",
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "Here's the analysis:\n\n* Item 1\n* Item 2",
+              },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+        });
+      }
+      // Second call (retry): return valid JSON
+      return Response.json(
+        makeSynapseResponse([
+          {
+            topicKey: "meeting",
+            priority: 1,
+            summary: "Meeting scheduled",
+            rawBufferIds: ["rb_1"],
+          },
+        ]),
+      );
+    };
+
+    const thalamus = new Thalamus(makeThalamusConfig());
+    await thalamus.syncAll();
+
+    expect(callCount).toBe(2);
+
+    // Inbox should have the message from retry
+    const msg = claimNextInboxMessage();
+    expect(msg).not.toBeNull();
+    expect(msg!.topic_key).toBe("meeting");
+
+    // Buffers should be deleted after successful retry
+    const remaining = getUnprocessedBuffers();
+    expect(remaining).toHaveLength(0);
+  });
+
+  test("preserves buffers when all parse attempts fail", async () => {
+    insertReceptorBuffer({
+      channel: "calendar",
+      externalId: "cal-1",
+      content: "Meeting tomorrow",
+      occurredAt: Date.now(),
+    });
+
+    let callCount = 0;
+    mockSynapseHandler = () => {
+      callCount++;
+      // Both calls return invalid JSON
+      return Response.json({
+        id: "chat-test",
+        object: "chat.completion",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Here's the analysis:\n\n* Item 1",
+            },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      });
+    };
+
+    const thalamus = new Thalamus(makeThalamusConfig());
+    await thalamus.syncAll();
+
+    expect(callCount).toBe(2);
+
+    // No inbox messages created
+    const msg = claimNextInboxMessage();
+    expect(msg).toBeNull();
+
+    // Buffers should be PRESERVED (not deleted)
+    const remaining = getUnprocessedBuffers();
+    expect(remaining).toHaveLength(1);
+  });
+
+  test("uses lower temperature (0.1) on retry", async () => {
+    insertReceptorBuffer({
+      channel: "calendar",
+      externalId: "cal-1",
+      content: "Meeting tomorrow",
+      occurredAt: Date.now(),
+    });
+
+    const capturedTemperatures: number[] = [];
+    mockSynapseHandler = async (req) => {
+      const body = (await req.json()) as { temperature?: number };
+      capturedTemperatures.push(body.temperature ?? -1);
+
+      if (capturedTemperatures.length === 1) {
+        // First call: return invalid JSON
+        return Response.json({
+          id: "chat-test",
+          object: "chat.completion",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: "not json" },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+        });
+      }
+      // Second call: return valid JSON
+      return Response.json(makeSynapseResponse([]));
+    };
+
+    const thalamus = new Thalamus(makeThalamusConfig());
+    await thalamus.syncAll();
+
+    expect(capturedTemperatures).toHaveLength(2);
+    expect(capturedTemperatures[0]).toBe(0.3); // First attempt
+    expect(capturedTemperatures[1]).toBe(0.1); // Retry with lower temp
+  });
+
+  test("includes correction prompt in retry request", async () => {
+    insertReceptorBuffer({
+      channel: "calendar",
+      externalId: "cal-1",
+      content: "Meeting tomorrow",
+      occurredAt: Date.now(),
+    });
+
+    const capturedMessages: Array<Array<{ role: string; content: string }>> =
+      [];
+    mockSynapseHandler = async (req) => {
+      const body = (await req.json()) as {
+        messages?: Array<{ role: string; content: string }>;
+      };
+      capturedMessages.push(body.messages ?? []);
+
+      if (capturedMessages.length === 1) {
+        // First call: return invalid JSON
+        return Response.json({
+          id: "chat-test",
+          object: "chat.completion",
+          choices: [
+            {
+              index: 0,
+              message: { role: "assistant", content: "bad response" },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+        });
+      }
+      // Second call: return valid JSON
+      return Response.json(makeSynapseResponse([]));
+    };
+
+    const thalamus = new Thalamus(makeThalamusConfig());
+    await thalamus.syncAll();
+
+    expect(capturedMessages).toHaveLength(2);
+
+    // First request: system + user
+    expect(capturedMessages[0]).toHaveLength(2);
+    expect(capturedMessages[0][0].role).toBe("system");
+    expect(capturedMessages[0][1].role).toBe("user");
+
+    // Retry request: system + user + assistant (bad response) + user (correction)
+    expect(capturedMessages[1]).toHaveLength(4);
+    expect(capturedMessages[1][0].role).toBe("system");
+    expect(capturedMessages[1][1].role).toBe("user");
+    expect(capturedMessages[1][2].role).toBe("assistant");
+    expect(capturedMessages[1][2].content).toBe("bad response");
+    expect(capturedMessages[1][3].role).toBe("user");
+    expect(capturedMessages[1][3].content).toContain("not valid JSON");
+  });
 });
 
 describe("thalamus.syncChannel()", () => {


### PR DESCRIPTION
## Summary

- Fixed bug where valid JSON with empty items `{"items":[]}` was treated the same as parse failures
- When LLM correctly triages buffers as "nothing noteworthy", buffers are now properly deleted
- When LLM returns invalid JSON (markdown, malformed), buffers are preserved for next sync cycle

## Changes

- `parseSyncOutput()` now returns `ParseResult { ok, items }` instead of just `SyncOutputItem[]`
- `processBuffers()` checks `parseResult.ok` instead of `items.length` to decide on retry
- Retry logic only triggers on actual parse failure, not on valid empty responses
- Buffer preservation only occurs on parse failure, not on legitimate empty results

## Root Cause

The `gpt-oss:20b` model sometimes returns markdown instead of valid JSON. The previous logic used `items.length === 0` to detect this, but this also matched the valid case where the LLM correctly determined nothing was noteworthy (returning `{"items":[]}`).

## Testing

- Added tests for retry with correction prompt on parse failure
- Added tests for buffer preservation when all parse attempts fail
- Added tests verifying lower temperature (0.1) on retry
- Added tests verifying correction prompt is included in retry request
- All 462 tests pass