### PR TITLE
feat(thalamus): sync on startup + expose buffer_pending_total

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1214,6 +1214,7 @@ export interface CortexStats {
     calendar_last_sync_at: number | null;
     calendar_buffer_pending: number;
     thalamus_last_run_at: number | null;
+    buffer_pending_total: number;
   };
   processing: {
     p50_ms: number | null;
@@ -1325,6 +1326,10 @@ export function getStats(thalamus?: ThalamusSyncInfo): CortexStats {
       calendar_last_sync_at: cursorByChannel.calendar ?? null,
       calendar_buffer_pending: bufferByChannel.calendar ?? 0,
       thalamus_last_run_at: thalamus?.getLastSyncAt() ?? null,
+      buffer_pending_total: Object.values(bufferByChannel).reduce(
+        (a, b) => a + b,
+        0,
+      ),
     },
     processing: {
       p50_ms: hasLatency ? percentile(latencies, 50) : null,

--- a/src/thalamus/index.ts
+++ b/src/thalamus/index.ts
@@ -84,6 +84,10 @@ export class Thalamus {
       return;
     }
     log(`thalamus started (sync interval: ${this.config.syncIntervalMs}ms)`);
+
+    // Immediate sync on startup to process any pending buffers
+    void this.syncAll();
+
     this.syncTimer = setInterval(
       () => void this.syncAll(),
       this.config.syncIntervalMs,

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -81,6 +81,7 @@ describe("stats API", () => {
       expect(stats.receptors.calendar_last_sync_at).toBeNull();
       expect(stats.receptors.calendar_buffer_pending).toBe(0);
       expect(stats.receptors.thalamus_last_run_at).toBeNull();
+      expect(stats.receptors.buffer_pending_total).toBe(0);
 
       // Processing latencies
       expect(stats.processing.p50_ms).toBeNull();
@@ -225,6 +226,47 @@ describe("stats API", () => {
       expect(stats.receptors.calendar_buffer_pending).toBe(2);
     });
 
+    test("sums buffer_pending_total across all channels", () => {
+      // Insert buffers across multiple channels
+      insertReceptorBuffer({
+        channel: "calendar",
+        externalId: "cal-1",
+        content: "Calendar event 1",
+        occurredAt: Date.now(),
+      });
+      insertReceptorBuffer({
+        channel: "calendar",
+        externalId: "cal-2",
+        content: "Calendar event 2",
+        occurredAt: Date.now(),
+      });
+      insertReceptorBuffer({
+        channel: "email",
+        externalId: "email-1",
+        content: "Email 1",
+        occurredAt: Date.now(),
+      });
+      insertReceptorBuffer({
+        channel: "telegram",
+        externalId: "tg-1",
+        content: "Telegram message",
+        occurredAt: Date.now(),
+      });
+
+      const stats = getStats();
+
+      // calendar_buffer_pending only counts calendar
+      expect(stats.receptors.calendar_buffer_pending).toBe(2);
+
+      // buffer_pending_total sums all channels: 2 + 1 + 1 = 4
+      expect(stats.receptors.buffer_pending_total).toBe(4);
+    });
+
+    test("buffer_pending_total is 0 when no buffers exist", () => {
+      const stats = getStats();
+      expect(stats.receptors.buffer_pending_total).toBe(0);
+    });
+
     test("computes processing latency percentiles", () => {
       // Create 10 messages with different processing times
       for (let i = 1; i <= 10; i++) {
@@ -320,6 +362,7 @@ describe("stats API", () => {
         data.receptors.thalamus_last_run_at === null ||
           typeof data.receptors.thalamus_last_run_at === "number",
       ).toBe(true);
+      expect(typeof data.receptors.buffer_pending_total).toBe("number");
 
       // Processing shape
       expect(

--- a/test/thalamus.test.ts
+++ b/test/thalamus.test.ts
@@ -836,3 +836,80 @@ describe("thalamus.syncChannel()", () => {
     expect(synapseCalled).toBe(false);
   });
 });
+
+describe("thalamus.start()", () => {
+  beforeEach(() => {
+    initDatabase(":memory:");
+  });
+
+  afterEach(() => {
+    closeDatabase();
+  });
+
+  test("triggers immediate syncAll on startup", async () => {
+    // Insert a buffer that should be processed on startup
+    insertReceptorBuffer({
+      channel: "calendar",
+      externalId: "cal-startup-1",
+      content: "Startup test event",
+      occurredAt: Date.now(),
+    });
+
+    let synapseCalled = false;
+    mockSynapseHandler = () => {
+      synapseCalled = true;
+      return Response.json(makeSynapseResponse([]));
+    };
+
+    const thalamus = new Thalamus(makeThalamusConfig());
+    await thalamus.start();
+
+    // Give a small delay for the async syncAll to run
+    await Bun.sleep(50);
+
+    // Synapse should have been called (syncAll was triggered)
+    expect(synapseCalled).toBe(true);
+
+    await thalamus.stop();
+  });
+
+  test("does not sync on startup when config is missing", async () => {
+    insertReceptorBuffer({
+      channel: "calendar",
+      externalId: "cal-startup-2",
+      content: "Test event",
+      occurredAt: Date.now(),
+    });
+
+    let synapseCalled = false;
+    mockSynapseHandler = () => {
+      synapseCalled = true;
+      return Response.json(makeSynapseResponse([]));
+    };
+
+    // No config = sync disabled
+    const thalamus = new Thalamus();
+    await thalamus.start();
+
+    await Bun.sleep(50);
+
+    // Synapse should NOT have been called
+    expect(synapseCalled).toBe(false);
+
+    await thalamus.stop();
+  });
+
+  test("sets lastSyncAt after startup sync", async () => {
+    mockSynapseHandler = () => Response.json(makeSynapseResponse([]));
+
+    const thalamus = new Thalamus(makeThalamusConfig());
+    expect(thalamus.getLastSyncAt()).toBeNull();
+
+    await thalamus.start();
+    await Bun.sleep(50);
+
+    expect(thalamus.getLastSyncAt()).not.toBeNull();
+
+    await thalamus.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- Thalamus now syncs immediately on startup instead of waiting for the first 6h interval tick
- Expose `buffer_pending_total` in `/stats` for Wilson dashboard triage indicator

## Changes

### Thalamus Sync on Startup
- Added `void this.syncAll()` call in `start()` before setting up interval timer
- Test added to verify sync happens immediately on startup

### Buffer Stats
- Added `buffer_pending_total: number` to `CortexStats.receptors` interface
- `getStats()` now sums pending buffers from `receptor_buffers` table

## Why
After a restart, pending calendar buffers would wait up to 6 hours before being processed. Now thalamus syncs immediately, ensuring buffers are triaged as soon as the service comes up.

Wilson PR #39 depends on this to display accurate triage health.

## Testing
- 528 tests pass (1629 expect() calls)
- `bun run validate` clean