### PR TITLE
refactor: remove calendar-specific stats from CortexStats

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1211,8 +1211,6 @@ export interface CortexStats {
     dead_total: number;
   };
   receptors: {
-    calendar_last_sync_at: number | null;
-    calendar_buffer_pending: number;
     thalamus_last_run_at: number | null;
     buffer_pending_total: number;
   };
@@ -1276,15 +1274,6 @@ export function getStats(thalamus?: ThalamusSyncInfo): CortexStats {
     outboxRows.map((r) => [r.status, r.count]),
   );
 
-  // Receptor cursors (last sync timestamps)
-  const cursorRows = database
-    .prepare(`SELECT channel, last_synced_at FROM receptor_cursors`)
-    .all() as { channel: string; last_synced_at: number }[];
-
-  const cursorByChannel = Object.fromEntries(
-    cursorRows.map((r) => [r.channel, r.last_synced_at]),
-  );
-
   // Receptor buffers pending (count per channel)
   const bufferRows = database
     .prepare(
@@ -1323,8 +1312,6 @@ export function getStats(thalamus?: ThalamusSyncInfo): CortexStats {
       dead_total: outboxByStatus.dead ?? 0,
     },
     receptors: {
-      calendar_last_sync_at: cursorByChannel.calendar ?? null,
-      calendar_buffer_pending: bufferByChannel.calendar ?? 0,
       thalamus_last_run_at: thalamus?.getLastSyncAt() ?? null,
       buffer_pending_total: Object.values(bufferByChannel).reduce(
         (a, b) => a + b,

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -78,8 +78,6 @@ describe("stats API", () => {
       expect(stats.outbox.dead_total).toBe(0);
 
       // Receptors
-      expect(stats.receptors.calendar_last_sync_at).toBeNull();
-      expect(stats.receptors.calendar_buffer_pending).toBe(0);
       expect(stats.receptors.thalamus_last_run_at).toBeNull();
       expect(stats.receptors.buffer_pending_total).toBe(0);
 
@@ -199,16 +197,7 @@ describe("stats API", () => {
       expect(stats.outbox.pending).toBe(2);
     });
 
-    test("reports receptor cursor timestamps", () => {
-      upsertReceptorCursor("calendar", "cursor-value-1");
-
-      const stats = getStats();
-      // last_synced_at is set to Date.now() by the function
-      expect(stats.receptors.calendar_last_sync_at).not.toBeNull();
-      expect(typeof stats.receptors.calendar_last_sync_at).toBe("number");
-    });
-
-    test("counts pending receptor buffers", () => {
+    test("counts pending receptor buffers (total across all channels)", () => {
       insertReceptorBuffer({
         channel: "calendar",
         externalId: "event-1",
@@ -223,7 +212,7 @@ describe("stats API", () => {
       });
 
       const stats = getStats();
-      expect(stats.receptors.calendar_buffer_pending).toBe(2);
+      expect(stats.receptors.buffer_pending_total).toBe(2);
     });
 
     test("sums buffer_pending_total across all channels", () => {
@@ -254,9 +243,6 @@ describe("stats API", () => {
       });
 
       const stats = getStats();
-
-      // calendar_buffer_pending only counts calendar
-      expect(stats.receptors.calendar_buffer_pending).toBe(2);
 
       // buffer_pending_total sums all channels: 2 + 1 + 1 = 4
       expect(stats.receptors.buffer_pending_total).toBe(4);
@@ -353,11 +339,6 @@ describe("stats API", () => {
       expect(typeof data.outbox.dead_total).toBe("number");
 
       // Receptors shape
-      expect(
-        data.receptors.calendar_last_sync_at === null ||
-          typeof data.receptors.calendar_last_sync_at === "number",
-      ).toBe(true);
-      expect(typeof data.receptors.calendar_buffer_pending).toBe("number");
       expect(
         data.receptors.thalamus_last_run_at === null ||
           typeof data.receptors.thalamus_last_run_at === "number",


### PR DESCRIPTION
## Summary

- Remove `calendar_last_sync_at` from `CortexStats.receptors` - now tracked by Wilson's CalendarChannel
- Remove `calendar_buffer_pending` from `CortexStats.receptors` - Wilson now has per-channel stats
- Keep `thalamus_last_run_at` and `buffer_pending_total` (channel-agnostic)
- Remove unused `cursorByChannel` query

## Context

This is a follow-up to shetty4l/wilson#41 which added per-channel stats tracking to Wilson. Calendar-specific stats are now owned by Wilson's CalendarChannel, making these Cortex fields redundant.

## Testing

- All 256 tests passing
- `bun run validate` passes (typecheck, lint, format, tests)