### PR TITLE
chore: suppress /stats endpoint from HTTP logs

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -387,7 +387,7 @@ export function startServer(
         }
       }
 
-      if (response) {
+      if (response && url.pathname !== "/stats") {
         const latency = (performance.now() - start).toFixed(0);
         log(`${req.method} ${url.pathname} ${response.status} ${latency}ms`);
       }


### PR DESCRIPTION
## Summary

- Skip logging for `/stats` endpoint requests to reduce log noise
- Dashboard polls `/stats` frequently, creating excessive log entries

## Related PRs

- shetty4l/synapse - same change
- shetty4l/engram - same change