### PR TITLE
fix: retry model fallback on 5xx errors, not just 429

### DIFF
--- a/src/synapse.ts
+++ b/src/synapse.ts
@@ -8,7 +8,7 @@
  * Cortex sends `{ model, messages }` and gets back a chat completion.
  *
  * Model fallback: when multiple models are provided, chat() iterates through
- * them on 429 (rate limit). Non-429 errors return immediately.
+ * them on 429 (rate limit) or 5xx (server error). Client errors (4xx) return immediately.
  */
 
 import { createLogger } from "@shetty4l/core/log";
@@ -135,9 +135,11 @@ export async function chat(
       const latency = ((performance.now() - startMs) / 1000).toFixed(1);
       lastError = `Synapse returned ${response.status}: ${body.slice(0, 500)}`;
 
-      // On 429 (rate limit), try the next model in the fallback chain
-      if (response.status === 429) {
-        log(`synapse ${model} 429 ${latency}s — trying next model`);
+      // On 429 (rate limit) or 5xx (server error), try the next model in the fallback chain
+      if (response.status === 429 || response.status >= 500) {
+        log(
+          `synapse ${model} ${response.status} ${latency}s — trying next model`,
+        );
         continue;
       }
 


### PR DESCRIPTION
## Summary

When Synapse returns a 5xx error (e.g., 502 "All providers exhausted"), Cortex now tries the next model in the fallback chain instead of returning immediately.

## Problem

Previously, model fallback only happened on 429 (rate limit). When all providers for a model failed (502), Cortex would return the error without trying other models like `gpt-oss:20b` on local-gpu.

## Solution

Changed the retry condition from `status === 429` to `status === 429 || status >= 500`.

## Behavior

| Status | Before | After |
|--------|--------|-------|
| 429 (rate limit) | Try next model | Try next model |
| 500 (server error) | Return error | Try next model |
| 502 (bad gateway) | Return error | Try next model |
| 503 (unavailable) | Return error | Try next model |
| 400 (bad request) | Return error | Return error |
| 401 (unauthorized) | Return error | Return error |

## Testing

All 548 tests pass.