### PR TITLE
fix: improve pipeline reliability

### DIFF
--- a/src/engram.ts
+++ b/src/engram.ts
@@ -234,6 +234,9 @@ export async function recallDual(
     merged.push(mem);
   }
 
+  // Sort by relevance (highest first)
+  merged.sort((a, b) => b.relevance - a.relevance);
+
   // Emit recall debug event
   const debug = getDebugLogger();
   const traceId = getTraceId();

--- a/src/thalamus/index.ts
+++ b/src/thalamus/index.ts
@@ -193,7 +193,7 @@ export class Thalamus {
       ],
       config.thalamusModels,
       config.synapseUrl,
-      { temperature: 0.3, timeoutMs: config.synapseTimeoutMs },
+      { temperature: 0.1, timeoutMs: config.synapseTimeoutMs },
     );
 
     if (!chatResult.ok) {

--- a/src/thalamus/prompts.ts
+++ b/src/thalamus/prompts.ts
@@ -49,6 +49,7 @@ Priority scale:
 Rules:
 - Group related items (e.g., multiple calendar events in the same week, related emails)
 - Use existing topic keys when a matching topic exists
+- IMPORTANT: If an existing topic is semantically related to incoming data, USE ITS EXACT KEY. Do not create variations.
 - For new topics, use a descriptive kebab-case key (e.g., "japan-trip-planning")
 - Each summary should be 1-3 sentences: what happened, what changed, what needs attention
 - Include the buffer IDs (id field) that belong to each group in rawBufferIds

--- a/test/engram.test.ts
+++ b/test/engram.test.ts
@@ -243,6 +243,31 @@ describe("recallDual", () => {
     expect(result.slice(4).map((m) => m.id)).toEqual(["g1", "g2", "g3", "g4"]);
   });
 
+  test("sorts merged memories by relevance (highest first)", async () => {
+    const topicMems = [
+      { ...makeMemory("t1", "Low relevance topic"), relevance: 0.3 },
+      { ...makeMemory("t2", "High relevance topic"), relevance: 0.9 },
+    ];
+    const globalMems = [
+      { ...makeMemory("g1", "Medium relevance global"), relevance: 0.6 },
+      { ...makeMemory("g2", "Very high relevance global"), relevance: 0.95 },
+    ];
+
+    mockHandler = async (req) => {
+      const body = (await req.json()) as { scope_id?: string };
+      if (body.scope_id) {
+        return Response.json(recallResponse(topicMems));
+      }
+      return Response.json(recallResponse(globalMems));
+    };
+
+    const result = await recallDual("test", "my-topic", mockUrl);
+
+    expect(result).toHaveLength(4);
+    // Sorted by relevance: g2 (0.95), t2 (0.9), g1 (0.6), t1 (0.3)
+    expect(result.map((m) => m.id)).toEqual(["g2", "t2", "g1", "t1"]);
+  });
+
   test("sends correct scope_id for topic call and none for global", async () => {
     const calls: Array<{ scope_id?: string; limit?: number }> = [];
 

--- a/test/thalamus.test.ts
+++ b/test/thalamus.test.ts
@@ -548,7 +548,7 @@ describe("thalamus.syncAll()", () => {
     await thalamus.syncAll();
 
     expect(capturedBody.model).toBe("gpt-oss:20b");
-    expect(capturedBody.temperature).toBe(0.3);
+    expect(capturedBody.temperature).toBe(0.1);
   });
 
   test("handles empty LLM items gracefully", async () => {
@@ -709,8 +709,8 @@ describe("thalamus.syncAll()", () => {
     await thalamus.syncAll();
 
     expect(capturedTemperatures).toHaveLength(2);
-    expect(capturedTemperatures[0]).toBe(0.3); // First attempt
-    expect(capturedTemperatures[1]).toBe(0.1); // Retry with lower temp
+    expect(capturedTemperatures[0]).toBe(0.1); // First attempt (deterministic for topic keys)
+    expect(capturedTemperatures[1]).toBe(0.1); // Retry with same temp
   });
 
   test("includes correction prompt in retry request", async () => {


### PR DESCRIPTION
## Summary

Fixes three pipeline issues:
1. **Memory recall** now returns memories sorted by relevance (highest first)
2. **Topic key fragmentation** reduced via stricter prompt rules + lower temperature
3. Prepares for model chain optimization (config change post-merge)

## Changes

- `src/engram.ts` — Sort memories by relevance descending in `recallDual()`
- `src/thalamus/prompts.ts` — Add "USE ITS EXACT KEY" rule for topic reuse
- `src/thalamus/index.ts` — Change initial triage temperature 0.3 → 0.1
- `test/engram.test.ts` — Add test for relevance sorting
- `test/thalamus.test.ts` — Update temperature expectation

## Validation

- 551 tests pass
- Typecheck, lint, format all pass

## Post-Merge Manual Steps (Mac Mini)

1. Prune Engram (manual SQL, keep 10-15 memories)
2. Delete `~/.local/share/cortex/cortex.db*`
3. Delete `~/.config/cortex/logs/pipeline.jsonl`
4. Update `~/.config/cortex/config.json`: models → `["gpt-oss:20b", "big-pickle"]`
5. Restart cortex