### PR TITLE
refactor: migrate state tables to @Persisted abstraction

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,63 +17,63 @@
     },
   },
   "packages": {
-    "@biomejs/biome": ["@biomejs/biome@2.4.3", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.3", "@biomejs/cli-darwin-x64": "2.4.3", "@biomejs/cli-linux-arm64": "2.4.3", "@biomejs/cli-linux-arm64-musl": "2.4.3", "@biomejs/cli-linux-x64": "2.4.3", "@biomejs/cli-linux-x64-musl": "2.4.3", "@biomejs/cli-win32-arm64": "2.4.3", "@biomejs/cli-win32-x64": "2.4.3" }, "bin": { "biome": "bin/biome" } }, "sha512-cBrjf6PNF6yfL8+kcNl85AjiK2YHNsbU0EvDOwiZjBPbMbQ5QcgVGFpjD0O52p8nec5O8NYw7PKw3xUR7fPAkQ=="],
+    "@biomejs/biome": ["@biomejs/biome@2.4.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.4", "@biomejs/cli-darwin-x64": "2.4.4", "@biomejs/cli-linux-arm64": "2.4.4", "@biomejs/cli-linux-arm64-musl": "2.4.4", "@biomejs/cli-linux-x64": "2.4.4", "@biomejs/cli-linux-x64-musl": "2.4.4", "@biomejs/cli-win32-arm64": "2.4.4", "@biomejs/cli-win32-x64": "2.4.4" }, "bin": { "biome": "bin/biome" } }, "sha512-tigwWS5KfJf0cABVd52NVaXyAVv4qpUXOWJ1rxFL8xF1RVoeS2q/LK+FHgYoKMclJCuRoCWAPy1IXaN9/mS61Q=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-eOafSFlI/CF4id2tlwq9CVHgeEqvTL5SrhWff6ZORp6S3NL65zdsR3ugybItkgF8Pf4D9GSgtbB6sE3UNgOM9w=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jZ+Xc6qvD6tTH5jM6eKX44dcbyNqJHssfl2nnwT6vma6B1sj7ZLTGIk6N5QwVBs5xGN52r3trk5fgd3sQ9We9A=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-V2+av4ilbWcBMNufTtMMXVW00nPwyIjI5qf7n9wSvUaZ+tt0EvMGk46g9sAFDJBEDOzSyoRXiSP6pCvKTOEbPA=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-Dh1a/+W+SUCXhEdL7TiX3ArPTFCQKJTI1mGncZNWfO+6suk+gYA4lNyJcBB+pwvF49uw0pEbUS49BgYOY4hzUg=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-0m+O0x9FgK99FAwDK+fiDtjs2wnqq7bvfj17KJVeCkTwT/liI+Q9njJG7lwXK0iSJVXeFNRIxukpVI3SifMYAA=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-V/NFfbWhsUU6w+m5WYbBenlEAz8eYnSqRMDMAW3K+3v0tYVkNyZn8VU0XPxk/lOqNXLSCCrV7FmV/u3SjCBShg=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-QuFzvsGo8BA4Xm7jGX5idkw6BqFblcCPySMTvq0AhGYnhUej5VJIDJbmTKfHqwjHepZiC4fA+T5i6wmiZolZNw=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-+sPAXq3bxmFwhVFJnSwkSF5Rw2ZAJMH3MF6C9IveAEOdSpgajPhoQhbbAK12SehN9j2QrHpk4J/cHsa/HqWaYQ=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.3", "", { "os": "linux", "cpu": "x64" }, "sha512-NVqh0saIU0u5OfOp/0jFdlKRE59+XyMvWmtx0f6Nm/2OpdxBl04coRIftBbY9d1gfu+23JVv4CItAqPYrjYh5w=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.4", "", { "os": "linux", "cpu": "x64" }, "sha512-R4+ZCDtG9kHArasyBO+UBD6jr/FcFCTH8QkNTOCu0pRJzCWyWC4EtZa2AmUZB5h3e0jD7bRV2KvrENcf8rndBg=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.3", "", { "os": "linux", "cpu": "x64" }, "sha512-qEc0OCpj/uytruQ4wLM0yWNJLZy0Up8H1Er5MW3SrstqM6J2d4XqdNA86xzCy8MQCHpoVZ3lFye3GBlIL4/ljw=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gGvFTGpOIQDb5CQ2VC0n9Z2UEqlP46c4aNgHmAMytYieTGEcfqhfCFnhs6xjt0S3igE6q5GLuIXtdQt3Izok+g=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-gRO96vrIARilv/Cp2ZnmNNL5LSZg3RO75GPp13hsLO3N4YVpE7saaMDp2bcyV48y2N2Pbit1brkGVGta0yd6VQ=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-trzCqM7x+Gn832zZHgr28JoYagQNX4CZkUZhMUac2YxvvyDRLJDrb5m9IA7CaZLlX6lTQmADVfLEKP1et1Ma4Q=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.3", "", { "os": "win32", "cpu": "x64" }, "sha512-vSm/vOJe06pf14aGHfHl3Ar91Nlx4YYmohElDJ+17UbRwe99n987S/MhAlQOkONqf1utJor04ChkCPmKb8SWdw=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.4", "", { "os": "win32", "cpu": "x64" }, "sha512-gnOHKVPFAAPrpoPt2t+Q6FZ7RPry/FDV3GcpU53P3PtLNnQjBmKyN2Vh/JtqXet+H4pme8CC76rScwdjDcT1/A=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.49.0", "", { "os": "android", "cpu": "arm" }, "sha512-2WPoh/2oK9r/i2R4o4J18AOrm3HVlWiHZ8TnuCaS4dX8m5ZzRmHW0I3eLxEurQLHWVruhQN7fHgZnah+ag5iQg=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.50.0", "", { "os": "android", "cpu": "arm" }, "sha512-G7MRGk/6NCe+L8ntonRdZP7IkBfEpiZ/he3buLK6JkLgMHgJShXZ+BeOwADmspXez7U7F7L1Anf4xLSkLHiGTg=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.49.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YqJAGvNB11EzoKm1euVhZntb79alhMvWW/j12bYqdvVxn6xzEQWrEDCJg9BPo3A3tBCSUBKH7bVkAiCBqK/L1w=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.50.0", "", { "os": "android", "cpu": "arm64" }, "sha512-GeSuMoJWCVpovJi/e3xDSNgjeR8WEZ6MCXL6EtPiCIM2NTzv7LbflARINTXTJy2oFBYyvdf/l2PwHzYo6EdXvg=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.49.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WFocCRlvVkMhChCJ2qpJfp1Gj/IjvyjuifH9Pex8m8yHonxxQa3d8DZYreuDQU3T4jvSY8rqhoRqnpc61Nlbxw=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.50.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-w3SY5YtxGnxCHPJ8Twl3KmS9oja1gERYk3AMoZ7Hv8P43ZtB6HVfs02TxvarxfL214Tm3uzvc2vn+DhtUNeKnw=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.49.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-BN0KniwvehbUfYztOMwEDkYoojGm/narf5oJf+/ap+6PnzMeWLezMaVARNIS0j3OdMkjHTEP8s3+GdPJ7WDywQ=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.50.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-hNfogDqy7tvmllXKBSlHo6k5x7dhTUVOHbMSE15CCAcXzmqf5883aPvBYPOq9AE7DpDUQUZ1kVE22YbiGW+tuw=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.49.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-SnkAc/DPIY6joMCiP/+53Q+N2UOGMU6ULvbztpmvPJNF/jYPGhNbKtN982uj2Gs6fpbxYkmyj08QnpkD4fbHJA=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.50.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ykZevOWEyu0nsxolA911ucxpEv0ahw8jfEeGWOwwb/VPoE4xoexuTOAiPNlWZNJqANlJl7yp8OyzCtXTUAxotw=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.49.0", "", { "os": "linux", "cpu": "arm" }, "sha512-6Z3EzRvpQVIpO7uFhdiGhdE8Mh3S2VWKLL9xuxVqD6fzPhyI3ugthpYXlCChXzO8FzcYIZ3t1+Kau+h2NY1hqA=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.50.0", "", { "os": "linux", "cpu": "arm" }, "sha512-hif3iDk7vo5GGJ4OLCCZAf2vjnU9FztGw4L0MbQL0M2iY9LKFtDMMiQAHmkF0PQGQMVbTYtPdXCLKVgdkiqWXQ=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.49.0", "", { "os": "linux", "cpu": "arm" }, "sha512-wdjXaQYAL/L25732mLlngfst4Jdmi/HLPVHb3yfCoP5mE3lO/pFFrmOJpqWodgv29suWY74Ij+RmJ/YIG5VuzQ=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.50.0", "", { "os": "linux", "cpu": "arm" }, "sha512-dVp9iSssiGAnTNey2Ruf6xUaQhdnvcFOJyRWd/mu5o2jVbFK15E5fbWGeFRfmuobu5QXuROtFga44+7DOS3PLg=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.49.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-oSHpm8zmSvAG1BWUumbDRSg7moJbnwoEXKAkwDf/xTQJOzvbUknq95NVQdw/AduZr5dePftalB8rzJNGBogUMg=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.50.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-1cT7yz2HA910CKA9NkH1ZJo50vTtmND2fkoW1oyiSb0j6WvNtJ0Wx2zoySfXWc/c+7HFoqRK5AbEoL41LOn9oA=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.49.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-xeqkMOARgGBlEg9BQuPDf6ZW711X6BT5qjDyeM5XNowCJeTSdmMhpePJjTEiVbbr3t21sIlK8RE6X5bc04nWyQ=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.50.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-++B3k/HEPFVlj89cOz8kWfQccMZB/aWL9AhsW7jPIkG++63Mpwb2cE9XOEsd0PATbIan78k2Gky+09uWM1d/gQ=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.49.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-uvcqRO6PnlJGbL7TeePhTK5+7/JXbxGbN+C6FVmfICDeeRomgQqrfVjf0lUrVpUU8ii8TSkIbNdft3M+oNlOsQ=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.50.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-Z9b/KpFMkx66w3gVBqjIC1AJBTZAGoI9+U+K5L4QM0CB/G0JSNC1es9b3Y0Vcrlvtdn8A+IQTkYjd/Q0uCSaZw=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.49.0", "", { "os": "linux", "cpu": "none" }, "sha512-Dw1HkdXAwHNH+ZDserHP2RzXQmhHtpsYYI0hf8fuGAVCIVwvS6w1+InLxpPMY25P8ASRNiFN3hADtoh6lI+4lg=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.50.0", "", { "os": "linux", "cpu": "none" }, "sha512-jvmuIw8wRSohsQlFNIST5uUwkEtEJmOQYr33bf/K2FrFPXHhM4KqGekI3ShYJemFS/gARVacQFgBzzJKCAyJjg=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.49.0", "", { "os": "linux", "cpu": "none" }, "sha512-EPlMYaA05tJ9km/0dI9K57iuMq3Tw+nHst7TNIegAJZrBPtsOtYaMFZEaWj02HA8FI5QvSnRHMt+CI+RIhXJBQ=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.50.0", "", { "os": "linux", "cpu": "none" }, "sha512-x+UrN47oYNh90nmAAyql8eQaaRpHbDPu5guasDg10+OpszUQ3/1+1J6zFMmV4xfIEgTcUXG/oI5fxJhF4eWCNA=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.49.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-yZiQL9qEwse34aMbnMb5VqiAWfDY+fLFuoJbHOuzB1OaJZbN1MRF9Nk+W89PIpGr5DNPDipwjZb8+Q7wOywoUQ=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.50.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-i/JLi2ljLUIVfekMj4ISmdt+Hn11wzYUdRRrkVUYsCWw7zAy5xV7X9iA+KMyM156LTFympa7s3oKBjuCLoTAUQ=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.49.0", "", { "os": "linux", "cpu": "x64" }, "sha512-CcCDwMMXSchNkhdgvhVn3DLZ4EnBXAD8o8+gRzahg+IdSt/72y19xBgShJgadIRF0TsRcV/MhDUMwL5N/W54aQ=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.50.0", "", { "os": "linux", "cpu": "x64" }, "sha512-/C7brhn6c6UUPccgSPCcpLQXcp+xKIW/3sji/5VZ8/OItL3tQ2U7KalHz887UxxSQeEOmd1kY6lrpuwFnmNqOA=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.49.0", "", { "os": "linux", "cpu": "x64" }, "sha512-u3HfKV8BV6t6UCCbN0RRiyqcymhrnpunVmLFI8sEa5S/EBu+p/0bJ3D7LZ2KT6PsBbrB71SWq4DeFrskOVgIZg=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.50.0", "", { "os": "linux", "cpu": "x64" }, "sha512-oDR1f+bGOYU8LfgtEW8XtotWGB63ghtcxk5Jm6IDTCk++rTA/IRMsjOid2iMd+1bW+nP9Mdsmcdc7VbPD3+iyQ=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.49.0", "", { "os": "none", "cpu": "arm64" }, "sha512-dRDpH9fw+oeUMpM4br0taYCFpW6jQtOuEIec89rOgDA1YhqwmeRcx0XYeCv7U48p57qJ1XZHeMGM9LdItIjfzA=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.50.0", "", { "os": "none", "cpu": "arm64" }, "sha512-4CmRGPp5UpvXyu4jjP9Tey/SrXDQLRvZXm4pb4vdZBxAzbFZkCyh0KyRy4txld/kZKTJlW4TO8N1JKrNEk+mWw=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.49.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-6rrKe/wL9tn0qnOy76i1/0f4Dc3dtQnibGlU4HqR/brVHlVjzLSoaH0gAFnLnznh9yQ6gcFTBFOPrcN/eKPDGA=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.50.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Fq0M6vsGcFsSfeuWAACDhd5KJrO85ckbEfe1EGuBj+KPyJz7KeWte2fSFrFGmNKNXyhEMyx4tbgxiWRujBM2KQ=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.49.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-CXHLWAtLs2xG/aVy1OZiYJzrULlq0QkYpI6cd7VKMrab+qur4fXVE/B1Bp1m0h1qKTj5/FTGg6oU4qaXMjS/ug=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.50.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-qTdWR9KwY/vxJGhHVIZG2eBOhidOQvOwzDxnX+jhW/zIVacal1nAhR8GLkiywW8BIFDkQKXo/zOfT+/DY+ns/w=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.49.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VteIelt78kwzSglOozaQcs6BCS4Lk0j+QA+hGV0W8UeyaqQ3XpbZRhDU55NW1PPvCy1tg4VXsTlEaPovqto7nQ=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.50.0", "", { "os": "win32", "cpu": "x64" }, "sha512-682t7npLC4G2Ca+iNlI9fhAKTcFPYYXJjwoa88H4q+u5HHHlsnL/gHULapX3iqp+A8FIJbgdylL5KMYo2LaluQ=="],
 
-    "@shetty4l/core": ["@shetty4l/core@0.1.33", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-k7/+4gULGXDOdnqLAFU7CJbCCUYP81xByewEtuKY27r6fj+uE3zvd7MQJ5R6LHQ0XmAkmMKRp/yrVXOHu4COyQ=="],
+    "@shetty4l/core": ["@shetty4l/core@0.1.34", "", { "bin": { "version-bump": "bin/version-bump.js" } }, "sha512-9WJe73ROAgFbVwCMM5GorEfA+SKhYIo5LAsCtgnVC2gGOabR8J+T7OsImTV1gs/qTy+PE0/ov/LwA2jO4Ad9dw=="],
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
@@ -83,7 +83,7 @@
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
-    "oxlint": ["oxlint@1.49.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.49.0", "@oxlint/binding-android-arm64": "1.49.0", "@oxlint/binding-darwin-arm64": "1.49.0", "@oxlint/binding-darwin-x64": "1.49.0", "@oxlint/binding-freebsd-x64": "1.49.0", "@oxlint/binding-linux-arm-gnueabihf": "1.49.0", "@oxlint/binding-linux-arm-musleabihf": "1.49.0", "@oxlint/binding-linux-arm64-gnu": "1.49.0", "@oxlint/binding-linux-arm64-musl": "1.49.0", "@oxlint/binding-linux-ppc64-gnu": "1.49.0", "@oxlint/binding-linux-riscv64-gnu": "1.49.0", "@oxlint/binding-linux-riscv64-musl": "1.49.0", "@oxlint/binding-linux-s390x-gnu": "1.49.0", "@oxlint/binding-linux-x64-gnu": "1.49.0", "@oxlint/binding-linux-x64-musl": "1.49.0", "@oxlint/binding-openharmony-arm64": "1.49.0", "@oxlint/binding-win32-arm64-msvc": "1.49.0", "@oxlint/binding-win32-ia32-msvc": "1.49.0", "@oxlint/binding-win32-x64-msvc": "1.49.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.14.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-YZffp0gM+63CJoRhHjtjRnwKtAgUnXM6j63YQ++aigji2NVvLGsUlrXo9gJUXZOdcbfShLYtA6RuTu8GZ4lzOQ=="],
+    "oxlint": ["oxlint@1.50.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.50.0", "@oxlint/binding-android-arm64": "1.50.0", "@oxlint/binding-darwin-arm64": "1.50.0", "@oxlint/binding-darwin-x64": "1.50.0", "@oxlint/binding-freebsd-x64": "1.50.0", "@oxlint/binding-linux-arm-gnueabihf": "1.50.0", "@oxlint/binding-linux-arm-musleabihf": "1.50.0", "@oxlint/binding-linux-arm64-gnu": "1.50.0", "@oxlint/binding-linux-arm64-musl": "1.50.0", "@oxlint/binding-linux-ppc64-gnu": "1.50.0", "@oxlint/binding-linux-riscv64-gnu": "1.50.0", "@oxlint/binding-linux-riscv64-musl": "1.50.0", "@oxlint/binding-linux-s390x-gnu": "1.50.0", "@oxlint/binding-linux-x64-gnu": "1.50.0", "@oxlint/binding-linux-x64-musl": "1.50.0", "@oxlint/binding-openharmony-arm64": "1.50.0", "@oxlint/binding-win32-arm64-msvc": "1.50.0", "@oxlint/binding-win32-ia32-msvc": "1.50.0", "@oxlint/binding-win32-x64-msvc": "1.50.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.14.1" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-iSJ4IZEICBma8cZX7kxIIz9PzsYLF2FaLAYN6RKu7VwRVKdu7RIgpP99bTZaGl//Yao7fsaGZLSEo5xBrI5ReQ=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,18 @@
 {
   "name": "cortex",
   "version": "0.0.0-dev",
-  "description": "Channel-agnostic life assistant runtime with tool-calling agent loop",
-  "type": "module",
   "main": "src/index.ts",
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.4",
+    "@types/bun": "latest",
+    "husky": "^9.1.7",
+    "oxlint": "^1.50.0",
+    "typescript": "^5.9.3"
+  },
   "bin": {
     "cortex": "./src/cli.ts"
   },
+  "description": "Channel-agnostic life assistant runtime with tool-calling agent loop",
   "scripts": {
     "start": "bun run src/index.ts",
     "typecheck": "tsc --noEmit",
@@ -18,14 +24,8 @@
     "version:bump": "bunx version-bump",
     "prepare": "husky"
   },
+  "type": "module",
   "dependencies": {
-    "@shetty4l/core": "^0.1.33"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^2.3.13",
-    "@types/bun": "latest",
-    "husky": "^9.0.0",
-    "oxlint": "^1.48.0",
-    "typescript": "^5.0.0"
+    "@shetty4l/core": "^0.1.34"
   }
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -81,18 +81,6 @@ const SCHEMA = `
   CREATE INDEX IF NOT EXISTS idx_turns_topic_created
     ON turns(topic_key, created_at);
 
-  CREATE TABLE IF NOT EXISTS extraction_cursors (
-    topic_key TEXT PRIMARY KEY,
-    last_extracted_rowid INTEGER NOT NULL,
-    turns_since_extraction INTEGER NOT NULL DEFAULT 0
-  );
-
-  CREATE TABLE IF NOT EXISTS topic_summaries (
-    topic_key TEXT PRIMARY KEY,
-    summary TEXT NOT NULL,
-    updated_at INTEGER NOT NULL
-  );
-
   CREATE TABLE IF NOT EXISTS topics (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL,
@@ -130,13 +118,6 @@ const SCHEMA = `
     UNIQUE(channel, external_id)
   );
   CREATE INDEX IF NOT EXISTS idx_receptor_buffers_channel_created ON receptor_buffers(channel, created_at);
-
-  CREATE TABLE IF NOT EXISTS receptor_cursors (
-    channel TEXT PRIMARY KEY,
-    cursor_value TEXT NOT NULL,
-    last_synced_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL
-  );
 
   CREATE TABLE IF NOT EXISTS pending_approvals (
     id TEXT PRIMARY KEY,
@@ -897,71 +878,6 @@ export function loadRecentTurns(topicKey: string, maxRows = 16): Turn[] {
     .all({ $topicKey: topicKey, $maxRows: maxRows }) as Turn[];
 }
 
-// --- Extraction cursor operations ---
-
-export interface ExtractionCursor {
-  topic_key: string;
-  last_extracted_rowid: number;
-  turns_since_extraction: number;
-}
-
-/**
- * Get the extraction cursor for a topic.
- * Returns null if no extraction has ever run for this topic.
- */
-export function getExtractionCursor(topicKey: string): ExtractionCursor | null {
-  const database = getDatabase();
-  return (
-    (database
-      .prepare(
-        "SELECT topic_key, last_extracted_rowid, turns_since_extraction FROM extraction_cursors WHERE topic_key = $topicKey",
-      )
-      .get({ $topicKey: topicKey }) as ExtractionCursor | null) ?? null
-  );
-}
-
-/**
- * Increment the turns-since-extraction counter for a topic.
- *
- * If no cursor exists, creates one with last_extracted_rowid = 0
- * and turns_since_extraction = 1 (first turn, no extraction yet).
- */
-export function incrementTurnsSinceExtraction(topicKey: string): void {
-  const database = getDatabase();
-  database
-    .prepare(
-      `INSERT INTO extraction_cursors (topic_key, last_extracted_rowid, turns_since_extraction)
-       VALUES ($topicKey, 0, 1)
-       ON CONFLICT(topic_key) DO UPDATE
-       SET turns_since_extraction = turns_since_extraction + 1`,
-    )
-    .run({ $topicKey: topicKey });
-}
-
-/**
- * Advance the extraction cursor after a successful extraction run.
- * Resets turns_since_extraction to 0.
- *
- * Uses MAX() as defense-in-depth — the caller (loop.ts) serializes
- * extraction per topic, so out-of-order advances should not occur,
- * but the guard is cheap and makes the invariant self-enforcing.
- */
-export function advanceExtractionCursor(
-  topicKey: string,
-  lastRowid: number,
-): void {
-  const database = getDatabase();
-  database
-    .prepare(
-      `INSERT INTO extraction_cursors (topic_key, last_extracted_rowid, turns_since_extraction)
-       VALUES ($topicKey, $lastRowid, 0)
-       ON CONFLICT(topic_key) DO UPDATE
-       SET last_extracted_rowid = MAX(last_extracted_rowid, $lastRowid),
-           turns_since_extraction = 0`,
-    )
-    .run({ $topicKey: topicKey, $lastRowid: lastRowid });
-}
-
 /**
  * Load turns newer than the extraction cursor for a topic.
  *
@@ -990,78 +906,6 @@ export function loadTurnsSinceCursor(
         ? { $topicKey: topicKey, $afterRowid: afterRowid, $limit: limit }
         : { $topicKey: topicKey, $afterRowid: afterRowid },
     ) as Array<Turn & { rowid: number }>;
-}
-
-// --- Topic summary operations ---
-
-/**
- * Get the cached topic summary for a topic.
- * Returns null if no summary exists yet.
- */
-export function getTopicSummary(topicKey: string): string | null {
-  const database = getDatabase();
-  const row = database
-    .prepare("SELECT summary FROM topic_summaries WHERE topic_key = $topicKey")
-    .get({ $topicKey: topicKey }) as { summary: string } | null;
-  return row?.summary ?? null;
-}
-
-/**
- * Upsert the cached topic summary for a topic.
- * Overwrites any existing summary (INSERT OR REPLACE on PK).
- */
-export function upsertTopicSummary(topicKey: string, summary: string): void {
-  const database = getDatabase();
-  database
-    .prepare(
-      `INSERT INTO topic_summaries (topic_key, summary, updated_at)
-       VALUES ($topicKey, $summary, $now)
-       ON CONFLICT(topic_key) DO UPDATE
-       SET summary = $summary, updated_at = $now`,
-    )
-    .run({ $topicKey: topicKey, $summary: summary, $now: Date.now() });
-}
-
-// --- Receptor cursor operations ---
-
-/**
- * Get the receptor cursor for a channel.
- * Returns null when no cursor exists for this channel.
- */
-export function getReceptorCursor(
-  channel: string,
-): { cursorValue: string; lastSyncedAt: number } | null {
-  const database = getDatabase();
-  const row = database
-    .prepare(
-      "SELECT cursor_value, last_synced_at FROM receptor_cursors WHERE channel = $channel",
-    )
-    .get({ $channel: channel }) as {
-    cursor_value: string;
-    last_synced_at: number;
-  } | null;
-
-  if (!row) return null;
-  return { cursorValue: row.cursor_value, lastSyncedAt: row.last_synced_at };
-}
-
-/**
- * Upsert the receptor cursor for a channel.
- */
-export function upsertReceptorCursor(
-  channel: string,
-  cursorValue: string,
-): void {
-  const database = getDatabase();
-  const now = Date.now();
-  database
-    .prepare(
-      `INSERT INTO receptor_cursors (channel, cursor_value, last_synced_at, updated_at)
-       VALUES ($channel, $cursorValue, $now, $now)
-       ON CONFLICT(channel) DO UPDATE
-       SET cursor_value = $cursorValue, last_synced_at = $now, updated_at = $now`,
-    )
-    .run({ $channel: channel, $cursorValue: cursorValue, $now: now });
 }
 
 // --- Receptor buffer operations ---

--- a/src/extraction.ts
+++ b/src/extraction.ts
@@ -20,15 +20,14 @@ import { createLogger } from "@shetty4l/core/log";
 import type { Result } from "@shetty4l/core/result";
 import { err, ok } from "@shetty4l/core/result";
 import type { CortexConfig } from "./config";
-import {
-  advanceExtractionCursor,
-  getExtractionCursor,
-  getTopicSummary,
-  loadTurnsSinceCursor,
-  upsertTopicSummary,
-} from "./db";
+import { loadTurnsSinceCursor } from "./db";
 import { getDebugLogger } from "./debug-logger";
 import { recall, remember } from "./engram";
+import {
+  ExtractionCursorState,
+  type StateLoader,
+  TopicSummaryState,
+} from "./state";
 import type { ChatMessage } from "./synapse";
 import { chat } from "./synapse";
 import { getTraceId } from "./trace";
@@ -81,21 +80,24 @@ interface ExtractedFact {
 export async function maybeExtract(
   topicKey: string,
   config: CortexConfig,
+  stateLoader: StateLoader,
 ): Promise<void> {
   // Guard: extraction disabled if no model configured
   if (!config.extractionModels) return;
 
+  // Load cursor state
+  const cursor = stateLoader.load(ExtractionCursorState, topicKey);
+
   // Check if extraction is due
-  const cursor = getExtractionCursor(topicKey);
-  if (!cursor || cursor.turns_since_extraction < config.extractionInterval) {
+  if (cursor.turnsSinceExtraction < config.extractionInterval) {
     return;
   }
 
   log(
-    `[${topicKey}] extraction triggered (${cursor.turns_since_extraction} turns since last)`,
+    `[${topicKey}] extraction triggered (${cursor.turnsSinceExtraction} turns since last)`,
   );
 
-  let afterRowid = cursor.last_extracted_rowid;
+  let afterRowid = cursor.lastExtractedRowid;
 
   // Loop to drain the backlog — each iteration processes up to
   // MAX_TURNS_PER_EXTRACTION turns, trimmed to fit within
@@ -116,8 +118,8 @@ export async function maybeExtract(
       MAX_TURNS_PER_EXTRACTION,
     );
     if (loaded.length === 0) {
-      // No more turns — advance cursor to reset counter
-      advanceExtractionCursor(topicKey, afterRowid);
+      // No more turns — reset counter
+      cursor.turnsSinceExtraction = 0;
       break;
     }
 
@@ -150,7 +152,9 @@ export async function maybeExtract(
     lastBatchTurns = extractableTurns;
 
     const lastRowid = turns[turns.length - 1].rowid;
-    advanceExtractionCursor(topicKey, lastRowid);
+    // Advance cursor and reset counter
+    cursor.lastExtractedRowid = lastRowid;
+    cursor.turnsSinceExtraction = 0;
     afterRowid = lastRowid;
 
     // Continue draining if the batch was trimmed (more turns remain at
@@ -170,7 +174,7 @@ export async function maybeExtract(
   // bad response), the summary call would likely fail too. Unprocessed turns
   // are retried on the next extraction cycle.
   if (lastBatchTurns.length > 0) {
-    await updateTopicSummary(topicKey, lastBatchTurns, config);
+    await updateTopicSummary(topicKey, lastBatchTurns, config, stateLoader);
   }
 }
 
@@ -287,9 +291,11 @@ async function updateTopicSummary(
   topicKey: string,
   turns: Array<{ role: string; content: string | null }>,
   config: CortexConfig,
+  stateLoader: StateLoader,
 ): Promise<Result<void>> {
   try {
-    const existingSummary = getTopicSummary(topicKey);
+    const summaryState = stateLoader.load(TopicSummaryState, topicKey);
+    const existingSummary = summaryState.summary;
     const messages = buildSummaryPrompt(turns, existingSummary);
 
     const result = await chat(
@@ -306,7 +312,7 @@ async function updateTopicSummary(
     if (summary.length === 0) return ok(undefined);
 
     // Write to local SQLite cache (fast reads at prompt time)
-    upsertTopicSummary(topicKey, summary);
+    summaryState.summary = summary;
 
     // Write to Engram (source of truth, upsert by topic key).
     // Category "summary" is intentionally outside VALID_CATEGORIES —

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,13 +12,14 @@ import { ChannelRegistry } from "./channels";
 import { SilentChannel } from "./channels/silent";
 import type { CortexConfig } from "./config";
 import { loadConfig } from "./config";
-import { initDatabase } from "./db";
+import { getDatabase, initDatabase } from "./db";
 import { initDebugLogger } from "./debug-logger";
 import { Hippocampus } from "./hippocampus";
 import { startProcessingLoop } from "./loop";
 import { RAS } from "./ras";
 import { startServer } from "./server";
 import { createEmptyRegistry, loadSkills, type SkillRegistry } from "./skills";
+import { StateLoader } from "./state";
 import { Thalamus } from "./thalamus";
 import { Tick } from "./tick";
 import { type BuiltinToolContext, createCombinedRegistry } from "./tools";
@@ -60,6 +61,7 @@ export interface CortexRuntime {
 export async function startCortexRuntime(
   config: CortexConfig,
   registry: SkillRegistry,
+  stateLoader: StateLoader,
   deps: RuntimeDeps = DEFAULT_RUNTIME_DEPS,
 ): Promise<CortexRuntime> {
   const thalamus = new Thalamus({
@@ -68,6 +70,9 @@ export async function startCortexRuntime(
     synapseTimeoutMs: config.synapseTimeoutMs,
     syncIntervalMs: config.thalamusSyncIntervalMs,
   });
+
+  // Set stateLoader for thalamus to persist sync timestamps
+  thalamus.setStateLoader(stateLoader);
 
   const server = deps.startServer(config, thalamus);
   deps.log(`listening on http://${config.host}:${config.port}`);
@@ -86,6 +91,7 @@ export async function startCortexRuntime(
 
   const loop = deps.startProcessingLoop(config, combinedRegistry, {
     builtinContext: builtinCtx,
+    stateLoader,
   });
   deps.log("processing loop started");
 
@@ -106,6 +112,7 @@ export async function startCortexRuntime(
       await channels.stopAll();
       await loop.stop();
       server.stop();
+      await stateLoader.flush();
     },
   };
 }
@@ -132,6 +139,9 @@ export async function run(): Promise<void> {
     process.exit(1);
   }
 
+  // Initialize state loader for persisted state classes
+  const stateLoader = new StateLoader(getDatabase());
+
   const registryResult =
     config.skillDirs.length > 0
       ? await loadSkills(config.skillDirs, config.skillConfig)
@@ -147,7 +157,7 @@ export async function run(): Promise<void> {
     `loaded ${registry.tools.length} tools from ${config.skillDirs.length} skill dirs`,
   );
 
-  const runtime = await startCortexRuntime(config, registry);
+  const runtime = await startCortexRuntime(config, registry, stateLoader);
   onShutdown(
     async () => {
       log("shutting down...");

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -21,8 +21,6 @@ import {
   claimNextInboxMessage,
   completeInboxMessage,
   enqueueOutboxMessage,
-  getTopicSummary,
-  incrementTurnsSinceExtraction,
   retryInboxMessage,
 } from "./db";
 import { getDebugLogger } from "./debug-logger";
@@ -31,6 +29,11 @@ import { maybeExtract } from "./extraction";
 import { loadHistory, saveAgentHistory, saveTurnPair } from "./history";
 import { buildPrompt, loadAndRenderSystemPrompt } from "./prompt";
 import type { SkillRegistry } from "./skills";
+import {
+  ExtractionCursorState,
+  type StateLoader,
+  TopicSummaryState,
+} from "./state";
 import type { OpenAITool } from "./synapse";
 import { chat } from "./synapse";
 import type { BuiltinToolContext } from "./tools";
@@ -90,6 +93,8 @@ export interface ProcessingLoopOptions {
   pollIdleMs?: number;
   /** Mutable context shared with built-in tools (topicKey updated per message). */
   builtinContext?: BuiltinToolContext;
+  /** StateLoader for persisted state classes. */
+  stateLoader?: StateLoader;
 }
 
 /**
@@ -109,6 +114,7 @@ export function startProcessingLoop(
   const pollBusyMs = options?.pollBusyMs ?? DEFAULT_POLL_BUSY_MS;
   const pollIdleMs = options?.pollIdleMs ?? DEFAULT_POLL_IDLE_MS;
   const builtinCtx = options?.builtinContext;
+  const stateLoader = options?.stateLoader;
 
   if (!config.extractionModels) {
     log("extraction disabled — no extractionModels configured");
@@ -184,8 +190,10 @@ export function startProcessingLoop(
             // 2. Load recent turn history
             const turns = loadHistory(message.topic_key);
 
-            // 3. Load topic summary (fast SQLite read)
-            const topicSummary = getTopicSummary(message.topic_key);
+            // 3. Load topic summary (fast SQLite read via StateLoader)
+            const topicSummary = stateLoader
+              ? stateLoader.load(TopicSummaryState, message.topic_key).summary
+              : null;
 
             log(
               `[${message.topic_key}] context: memories=${memories.length} turns=${turns.length}`,
@@ -303,11 +311,17 @@ export function startProcessingLoop(
               // 7. Trigger async extraction (fire-and-forget, serialized per topic)
               //    Always increment the turn counter — even when extraction is
               //    already in-flight — so the cadence stays accurate.
-              if (config.extractionModels) {
-                incrementTurnsSinceExtraction(message.topic_key);
+              if (config.extractionModels && stateLoader) {
+                const cursor = stateLoader.load(
+                  ExtractionCursorState,
+                  message.topic_key,
+                );
+                cursor.turnsSinceExtraction += 1;
+                // Flush immediately so maybeExtract sees the updated counter
+                await stateLoader.flush();
               }
-              if (!extractionInFlight.has(message.topic_key)) {
-                const p = maybeExtract(message.topic_key, config)
+              if (stateLoader && !extractionInFlight.has(message.topic_key)) {
+                const p = maybeExtract(message.topic_key, config, stateLoader)
                   .catch((e) =>
                     log(
                       `[${message.topic_key}] extraction error: ${e instanceof Error ? e.message : String(e)}`,

--- a/src/state/extraction-cursor.ts
+++ b/src/state/extraction-cursor.ts
@@ -1,0 +1,14 @@
+/**
+ * Extraction cursor state.
+ *
+ * Tracks extraction progress per topic: which turns have been processed
+ * and how many turns have occurred since the last extraction.
+ */
+
+import { Field, Persisted } from "@shetty4l/core/state";
+
+@Persisted("extraction_cursors")
+export class ExtractionCursorState {
+  @Field("number") lastExtractedRowid: number = 0;
+  @Field("number") turnsSinceExtraction: number = 0;
+}

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,0 +1,11 @@
+/**
+ * State classes for Cortex.
+ *
+ * Re-exports all @Persisted state classes and the StateLoader type.
+ */
+
+export { StateLoader } from "@shetty4l/core/state";
+export { ExtractionCursorState } from "./extraction-cursor";
+export { ReceptorCursorState } from "./receptor-cursor";
+export { ThalamusState } from "./thalamus";
+export { TopicSummaryState } from "./topic-summary";

--- a/src/state/receptor-cursor.ts
+++ b/src/state/receptor-cursor.ts
@@ -1,0 +1,14 @@
+/**
+ * Receptor cursor state.
+ *
+ * Tracks the sync cursor for each receptor channel. Used to record when
+ * a channel was last synced during thalamus processing.
+ */
+
+import { Field, Persisted } from "@shetty4l/core/state";
+
+@Persisted("receptor_cursors")
+export class ReceptorCursorState {
+  @Field("string") cursorValue: string | null = null;
+  @Field("date") lastSyncedAt: Date | null = null;
+}

--- a/src/state/thalamus.ts
+++ b/src/state/thalamus.ts
@@ -1,0 +1,13 @@
+/**
+ * Thalamus state.
+ *
+ * Tracks the last sync timestamp for the thalamus sync loop.
+ * Persists across restarts so the stats API can report accurate timestamps.
+ */
+
+import { Field, Persisted } from "@shetty4l/core/state";
+
+@Persisted("thalamus_state")
+export class ThalamusState {
+  @Field("date") lastSyncAt: Date | null = null;
+}

--- a/src/state/topic-summary.ts
+++ b/src/state/topic-summary.ts
@@ -1,0 +1,14 @@
+/**
+ * Topic summary state.
+ *
+ * Caches the rolling summary for a topic. The summary is also stored in
+ * Engram as the source of truth, but this local cache provides fast reads
+ * at prompt time without network calls.
+ */
+
+import { Field, Persisted } from "@shetty4l/core/state";
+
+@Persisted("topic_summaries")
+export class TopicSummaryState {
+  @Field("string") summary: string | null = null;
+}

--- a/src/thalamus/index.ts
+++ b/src/thalamus/index.ts
@@ -5,8 +5,8 @@ import {
   enqueueInboxMessage,
   getUnprocessedBuffers,
   insertReceptorBuffer,
-  upsertReceptorCursor,
 } from "../db";
+import { ReceptorCursorState, type StateLoader, ThalamusState } from "../state";
 import { chat } from "../synapse";
 import { listTopics } from "../topics";
 import { formatChannelData } from "./formatters";
@@ -69,13 +69,21 @@ export interface SyncResult {
 
 export class Thalamus {
   private syncTimer: ReturnType<typeof setInterval> | null = null;
-  private lastSyncAt: number | null = null;
+  private stateLoader: StateLoader | null = null;
+  private thalamusState: ThalamusState | null = null;
 
   constructor(private config?: ThalamusConfig) {}
 
+  /** Set the StateLoader for persistent state. */
+  setStateLoader(stateLoader: StateLoader): void {
+    this.stateLoader = stateLoader;
+    // Load the thalamus state once when stateLoader is set
+    this.thalamusState = stateLoader.load(ThalamusState, "singleton");
+  }
+
   /** Returns the timestamp of the last syncAll() run, or null if never run. */
   getLastSyncAt(): number | null {
-    return this.lastSyncAt;
+    return this.thalamusState?.lastSyncAt?.getTime() ?? null;
   }
 
   async start(): Promise<void> {
@@ -103,7 +111,10 @@ export class Thalamus {
   }
 
   async syncAll(): Promise<SyncResult> {
-    this.lastSyncAt = Date.now();
+    // Update persistent timestamp
+    if (this.thalamusState) {
+      this.thalamusState.lastSyncAt = new Date();
+    }
 
     if (!this.config) {
       log("thalamus syncAll: no config, skipping");
@@ -259,8 +270,12 @@ export class Thalamus {
     }
 
     // Update receptor cursors per channel
-    for (const channel of grouped.keys()) {
-      upsertReceptorCursor(channel, String(Date.now()));
+    if (this.stateLoader) {
+      for (const channel of grouped.keys()) {
+        const cursorState = this.stateLoader.load(ReceptorCursorState, channel);
+        cursorState.cursorValue = String(Date.now());
+        cursorState.lastSyncedAt = new Date();
+      }
     }
 
     // Delete processed buffers

--- a/test/extraction.test.ts
+++ b/test/extraction.test.ts
@@ -9,17 +9,19 @@ import {
 } from "bun:test";
 import type { CortexConfig } from "../src/config";
 import {
-  advanceExtractionCursor,
   closeDatabase,
-  getExtractionCursor,
-  getTopicSummary,
-  incrementTurnsSinceExtraction,
+  getDatabase,
   initDatabase,
   loadTurnsSinceCursor,
   saveAgentTurns,
   saveTurn,
 } from "../src/db";
 import { maybeExtract, trimToBudget } from "../src/extraction";
+import {
+  ExtractionCursorState,
+  StateLoader,
+  TopicSummaryState,
+} from "../src/state";
 
 // --- Mock Synapse server (extraction model) ---
 
@@ -99,7 +101,38 @@ afterAll(() => {
   mockEngram.stop(true);
 });
 
+// --- StateLoader helper functions ---
+
+function getExtractionCursor(topicKey: string) {
+  const state = stateLoader.load(ExtractionCursorState, topicKey);
+  return {
+    topic_key: topicKey,
+    last_extracted_rowid: state.lastExtractedRowid,
+    turns_since_extraction: state.turnsSinceExtraction,
+  };
+}
+
+async function incrementTurnsSinceExtraction(topicKey: string) {
+  const state = stateLoader.load(ExtractionCursorState, topicKey);
+  state.turnsSinceExtraction += 1;
+  await stateLoader.flush();
+}
+
+async function advanceExtractionCursor(topicKey: string, lastRowid: number) {
+  const state = stateLoader.load(ExtractionCursorState, topicKey);
+  state.lastExtractedRowid = lastRowid;
+  state.turnsSinceExtraction = 0;
+  await stateLoader.flush();
+}
+
+function getTopicSummary(topicKey: string): string | null {
+  const state = stateLoader.load(TopicSummaryState, topicKey);
+  return state.summary;
+}
+
 // --- Test config ---
+
+let stateLoader: StateLoader;
 
 function testConfig(overrides?: Partial<CortexConfig>): CortexConfig {
   return {
@@ -170,9 +203,11 @@ async function processAndExtract(
   config: CortexConfig,
 ): Promise<void> {
   if (config.extractionModels) {
-    incrementTurnsSinceExtraction(topicKey);
+    await incrementTurnsSinceExtraction(topicKey);
   }
-  await maybeExtract(topicKey, config);
+  await maybeExtract(topicKey, config, stateLoader);
+  // Flush to ensure cursor changes are persisted before tests read them back
+  await stateLoader.flush();
 }
 
 /**
@@ -199,45 +234,47 @@ function mockSynapseWithFacts(
 describe("extraction cursors (DB)", () => {
   beforeEach(() => {
     initDatabase(":memory:");
+    stateLoader = new StateLoader(getDatabase());
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await stateLoader.flush();
     closeDatabase();
   });
 
-  test("getExtractionCursor returns null for unknown topic", () => {
+  test("getExtractionCursor returns defaults for new topic", () => {
     const cursor = getExtractionCursor("unknown-topic");
-    expect(cursor).toBeNull();
+    expect(cursor.last_extracted_rowid).toBe(0);
+    expect(cursor.turns_since_extraction).toBe(0);
   });
 
-  test("incrementTurnsSinceExtraction creates cursor on first call", () => {
-    incrementTurnsSinceExtraction("topic-1");
+  test("incrementTurnsSinceExtraction increments counter", async () => {
+    await incrementTurnsSinceExtraction("topic-1");
     const cursor = getExtractionCursor("topic-1");
 
-    expect(cursor).not.toBeNull();
-    expect(cursor!.last_extracted_rowid).toBe(0);
-    expect(cursor!.turns_since_extraction).toBe(1);
+    expect(cursor.last_extracted_rowid).toBe(0);
+    expect(cursor.turns_since_extraction).toBe(1);
   });
 
-  test("incrementTurnsSinceExtraction increments on subsequent calls", () => {
-    incrementTurnsSinceExtraction("topic-1");
-    incrementTurnsSinceExtraction("topic-1");
-    incrementTurnsSinceExtraction("topic-1");
+  test("incrementTurnsSinceExtraction increments on subsequent calls", async () => {
+    await incrementTurnsSinceExtraction("topic-1");
+    await incrementTurnsSinceExtraction("topic-1");
+    await incrementTurnsSinceExtraction("topic-1");
 
     const cursor = getExtractionCursor("topic-1");
-    expect(cursor!.turns_since_extraction).toBe(3);
+    expect(cursor.turns_since_extraction).toBe(3);
   });
 
-  test("advanceExtractionCursor resets counter", () => {
-    incrementTurnsSinceExtraction("topic-1");
-    incrementTurnsSinceExtraction("topic-1");
-    incrementTurnsSinceExtraction("topic-1");
+  test("advanceExtractionCursor resets counter", async () => {
+    await incrementTurnsSinceExtraction("topic-1");
+    await incrementTurnsSinceExtraction("topic-1");
+    await incrementTurnsSinceExtraction("topic-1");
 
-    advanceExtractionCursor("topic-1", 42);
+    await advanceExtractionCursor("topic-1", 42);
 
     const cursor = getExtractionCursor("topic-1");
-    expect(cursor!.last_extracted_rowid).toBe(42);
-    expect(cursor!.turns_since_extraction).toBe(0);
+    expect(cursor.last_extracted_rowid).toBe(42);
+    expect(cursor.turns_since_extraction).toBe(0);
   });
 
   test("loadTurnsSinceCursor returns turns after rowid", () => {
@@ -279,6 +316,7 @@ describe("extraction cursors (DB)", () => {
 describe("maybeExtract", () => {
   beforeEach(() => {
     initDatabase(":memory:");
+    stateLoader = new StateLoader(getDatabase());
     engramRememberCalls = [];
     engramSummaryCalls = [];
     engramRecallCalls = [];
@@ -296,7 +334,8 @@ describe("maybeExtract", () => {
     };
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await stateLoader.flush();
     closeDatabase();
   });
 
@@ -304,10 +343,12 @@ describe("maybeExtract", () => {
     const config = testConfig({ extractionModels: undefined });
     seedTurns("topic-1", 5);
 
-    await maybeExtract("topic-1", config);
+    await maybeExtract("topic-1", config, stateLoader);
 
-    // No cursor created, no model call
-    expect(getExtractionCursor("topic-1")).toBeNull();
+    // Cursor not touched when extraction disabled, stays at defaults
+    const cursor = getExtractionCursor("topic-1");
+    expect(cursor.turns_since_extraction).toBe(0);
+    expect(cursor.last_extracted_rowid).toBe(0);
     expect(engramRememberCalls).toHaveLength(0);
   });
 
@@ -319,7 +360,7 @@ describe("maybeExtract", () => {
     await processAndExtract("topic-1", config);
 
     const cursor = getExtractionCursor("topic-1");
-    expect(cursor!.turns_since_extraction).toBe(1);
+    expect(cursor.turns_since_extraction).toBe(1);
     expect(engramRememberCalls).toHaveLength(0);
   });
 
@@ -381,7 +422,7 @@ describe("maybeExtract", () => {
 
     // Reset cursor to force re-extraction of same turns
     engramRememberCalls = [];
-    advanceExtractionCursor("topic-1", 0);
+    await advanceExtractionCursor("topic-1", 0);
 
     // Add another turn to trigger extraction again
     seedTurns("topic-1", 1);
@@ -403,8 +444,8 @@ describe("maybeExtract", () => {
     await processAndExtract("topic-1", config);
 
     const cursor = getExtractionCursor("topic-1");
-    expect(cursor!.turns_since_extraction).toBe(0);
-    expect(cursor!.last_extracted_rowid).toBeGreaterThan(0);
+    expect(cursor.turns_since_extraction).toBe(0);
+    expect(cursor.last_extracted_rowid).toBeGreaterThan(0);
   });
 
   test("cursor does NOT advance on model call failure", async () => {
@@ -421,8 +462,8 @@ describe("maybeExtract", () => {
 
     const cursor = getExtractionCursor("topic-1");
     // Counter was incremented but cursor NOT advanced
-    expect(cursor!.turns_since_extraction).toBe(1);
-    expect(cursor!.last_extracted_rowid).toBe(0);
+    expect(cursor.turns_since_extraction).toBe(1);
+    expect(cursor.last_extracted_rowid).toBe(0);
   });
 
   test("cursor does NOT advance on malformed JSON response", async () => {
@@ -437,8 +478,8 @@ describe("maybeExtract", () => {
     await processAndExtract("topic-1", config);
 
     const cursor = getExtractionCursor("topic-1");
-    expect(cursor!.turns_since_extraction).toBe(1);
-    expect(cursor!.last_extracted_rowid).toBe(0);
+    expect(cursor.turns_since_extraction).toBe(1);
+    expect(cursor.last_extracted_rowid).toBe(0);
   });
 
   test("cursor advances even if all remember calls fail", async () => {
@@ -463,8 +504,8 @@ describe("maybeExtract", () => {
 
     const cursor = getExtractionCursor("topic-1");
     // Cursor advanced despite remember failure (upsert makes re-extraction safe)
-    expect(cursor!.turns_since_extraction).toBe(0);
-    expect(cursor!.last_extracted_rowid).toBeGreaterThan(0);
+    expect(cursor.turns_since_extraction).toBe(0);
+    expect(cursor.last_extracted_rowid).toBeGreaterThan(0);
   });
 
   test("empty extraction result advances cursor", async () => {
@@ -475,8 +516,8 @@ describe("maybeExtract", () => {
     await processAndExtract("topic-1", config);
 
     const cursor = getExtractionCursor("topic-1");
-    expect(cursor!.turns_since_extraction).toBe(0);
-    expect(cursor!.last_extracted_rowid).toBeGreaterThan(0);
+    expect(cursor.turns_since_extraction).toBe(0);
+    expect(cursor.last_extracted_rowid).toBeGreaterThan(0);
     // No fact remember calls, but summary is stored
     expect(engramRememberCalls).toHaveLength(0);
     expect(engramSummaryCalls).toHaveLength(1);
@@ -746,13 +787,15 @@ describe("trimToBudget", () => {
 describe("maybeExtract with oversized batches", () => {
   beforeEach(() => {
     initDatabase(":memory:");
+    stateLoader = new StateLoader(getDatabase());
     engramRememberCalls = [];
     engramSummaryCalls = [];
     engramRecallCalls = [];
     mockEngramHandler = defaultEngramHandler;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await stateLoader.flush();
     closeDatabase();
   });
 
@@ -787,12 +830,12 @@ describe("maybeExtract with oversized batches", () => {
 
     // Cursor should be fully advanced (all turns processed)
     const cursor = getExtractionCursor("topic-1");
-    expect(cursor!.turns_since_extraction).toBe(0);
+    expect(cursor.turns_since_extraction).toBe(0);
 
     // Verify all turns are behind the cursor
     const remaining = loadTurnsSinceCursor(
       "topic-1",
-      cursor!.last_extracted_rowid,
+      cursor.last_extracted_rowid,
     );
     expect(remaining).toHaveLength(0);
   });
@@ -801,6 +844,7 @@ describe("maybeExtract with oversized batches", () => {
 describe("topic summary generation", () => {
   beforeEach(() => {
     initDatabase(":memory:");
+    stateLoader = new StateLoader(getDatabase());
     engramRememberCalls = [];
     engramSummaryCalls = [];
     engramRecallCalls = [];
@@ -817,7 +861,8 @@ describe("topic summary generation", () => {
     };
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await stateLoader.flush();
     closeDatabase();
   });
 
@@ -924,7 +969,7 @@ describe("topic summary generation", () => {
 
     // Cursor still advanced
     const cursor = getExtractionCursor("topic-1");
-    expect(cursor!.turns_since_extraction).toBe(0);
+    expect(cursor.turns_since_extraction).toBe(0);
   });
 
   test("summary not generated when extraction fails", async () => {

--- a/test/index-wiring.test.ts
+++ b/test/index-wiring.test.ts
@@ -1,9 +1,11 @@
+import type { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import type { Channel } from "../src/channels";
 import { ChannelRegistry } from "../src/channels";
 import type { CortexConfig } from "../src/config";
 import { startCortexRuntime } from "../src/index";
 import { createEmptyRegistry } from "../src/skills";
+import { StateLoader } from "../src/state";
 
 function testConfig(overrides: Partial<CortexConfig> = {}): CortexConfig {
   return {
@@ -50,13 +52,22 @@ function mockChannel(name: string, events: string[]): Channel {
   };
 }
 
+function mockStateLoader(): StateLoader {
+  // Create a mock database for StateLoader
+  const { Database } = require("bun:sqlite");
+  const db = new Database(":memory:");
+  return new StateLoader(db as Database);
+}
+
 describe("index runtime wiring", () => {
   test("starts channels via registry after server and loop", async () => {
     const events: string[] = [];
+    const stateLoader = mockStateLoader();
 
     const runtime = await startCortexRuntime(
       testConfig(),
       createEmptyRegistry(),
+      stateLoader,
       {
         startServer: () => {
           events.push("server:start");
@@ -104,10 +115,12 @@ describe("index runtime wiring", () => {
 
   test("runs with no channels when registry is empty", async () => {
     const events: string[] = [];
+    const stateLoader = mockStateLoader();
 
     const runtime = await startCortexRuntime(
       testConfig(),
       createEmptyRegistry(),
+      stateLoader,
       {
         startServer: () => {
           events.push("server:start");
@@ -143,10 +156,12 @@ describe("index runtime wiring", () => {
 
   test("stops channels before loop and server (reverse order)", async () => {
     const events: string[] = [];
+    const stateLoader = mockStateLoader();
 
     const runtime = await startCortexRuntime(
       testConfig(),
       createEmptyRegistry(),
+      stateLoader,
       {
         startServer: () => {
           events.push("server:start");

--- a/test/loop.test.ts
+++ b/test/loop.test.ts
@@ -18,9 +18,7 @@ import {
   computeBackoffDelay,
   enqueueInboxMessage,
   getDatabase,
-  getExtractionCursor,
   getInboxMessage,
-  getTopicSummary,
   initDatabase,
   listOutboxMessagesByTopic,
   loadRecentTurns,
@@ -30,6 +28,31 @@ import { isTransientError, startProcessingLoop } from "../src/loop";
 import { DEFAULT_SYSTEM_PROMPT_TEMPLATE } from "../src/prompt";
 import type { SkillRegistry } from "../src/skills";
 import { createEmptyRegistry } from "../src/skills";
+import {
+  ExtractionCursorState,
+  StateLoader,
+  TopicSummaryState,
+} from "../src/state";
+
+// --- StateLoader instance (initialized in beforeEach) ---
+
+let stateLoader: StateLoader;
+
+// --- StateLoader helper functions ---
+
+function getExtractionCursor(topicKey: string) {
+  const state = stateLoader.load(ExtractionCursorState, topicKey);
+  return {
+    topic_key: topicKey,
+    last_extracted_rowid: state.lastExtractedRowid,
+    turns_since_extraction: state.turnsSinceExtraction,
+  };
+}
+
+function getTopicSummary(topicKey: string): string | null {
+  const state = stateLoader.load(TopicSummaryState, topicKey);
+  return state.summary;
+}
 
 // --- Mock Synapse server ---
 
@@ -172,13 +195,16 @@ async function waitFor(
 }
 
 /** Fast poll intervals for tests — avoids 2s idle sleep. */
-const FAST_LOOP = { pollBusyMs: 10, pollIdleMs: 50 };
+function makeFastLoop() {
+  return { pollBusyMs: 10, pollIdleMs: 50, stateLoader };
+}
 
 // --- Tests ---
 
 describe("processing loop", () => {
   beforeEach(() => {
     initDatabase(":memory:");
+    stateLoader = new StateLoader(getDatabase());
     mockSynapseCallCount = 0;
     // Default Engram mock: handle both recall and remember
     mockEngramHandler = async (req) => {
@@ -193,7 +219,8 @@ describe("processing loop", () => {
     };
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await stateLoader.flush();
     closeDatabase();
   });
 
@@ -202,7 +229,11 @@ describe("processing loop", () => {
 
     const { eventId } = ingestMessage({ text: "Hello assistant" });
     const config = testConfig();
-    const loop = startProcessingLoop(config, createEmptyRegistry(), FAST_LOOP);
+    const loop = startProcessingLoop(
+      config,
+      createEmptyRegistry(),
+      makeFastLoop(),
+    );
 
     await waitFor(() => {
       const msg = getInboxMessage(eventId);
@@ -237,7 +268,7 @@ describe("processing loop", () => {
     const loop = startProcessingLoop(
       testConfig(),
       createEmptyRegistry(),
-      FAST_LOOP,
+      makeFastLoop(),
     );
 
     await waitFor(() => mockSynapseCallCount > 0);
@@ -283,7 +314,7 @@ describe("processing loop", () => {
     const loop = startProcessingLoop(
       testConfig(),
       createEmptyRegistry(),
-      FAST_LOOP,
+      makeFastLoop(),
     );
 
     await waitFor(() => {
@@ -327,7 +358,7 @@ describe("processing loop", () => {
     const loop = startProcessingLoop(
       testConfig(),
       createEmptyRegistry(),
-      FAST_LOOP,
+      makeFastLoop(),
     );
 
     await waitFor(() => {
@@ -359,7 +390,7 @@ describe("processing loop", () => {
     const loop = startProcessingLoop(
       testConfig(),
       createEmptyRegistry(),
-      FAST_LOOP,
+      makeFastLoop(),
     );
 
     await waitFor(() => {
@@ -404,7 +435,7 @@ describe("processing loop", () => {
     const loop = startProcessingLoop(
       testConfig(),
       createEmptyRegistry(),
-      FAST_LOOP,
+      makeFastLoop(),
     );
 
     // First call: 502 → transient → retry (but with backoff delay)
@@ -433,7 +464,7 @@ describe("processing loop", () => {
     const loop = startProcessingLoop(
       testConfig(),
       createEmptyRegistry(),
-      FAST_LOOP,
+      makeFastLoop(),
     );
 
     // Let it tick a couple of times on empty inbox
@@ -468,7 +499,7 @@ describe("processing loop", () => {
     const loop = startProcessingLoop(
       testConfig(),
       createEmptyRegistry(),
-      FAST_LOOP,
+      makeFastLoop(),
     );
 
     await waitFor(() => {
@@ -495,7 +526,7 @@ describe("processing loop", () => {
     const loop = startProcessingLoop(
       testConfig(),
       createEmptyRegistry(),
-      FAST_LOOP,
+      makeFastLoop(),
     );
 
     await waitFor(() => getInboxMessage(eventId)?.status === "done");
@@ -523,7 +554,7 @@ describe("processing loop", () => {
     const loop = startProcessingLoop(
       testConfig(),
       createEmptyRegistry(),
-      FAST_LOOP,
+      makeFastLoop(),
     );
 
     await waitFor(() => getInboxMessage(eventId)?.status === "failed");
@@ -555,7 +586,7 @@ describe("processing loop", () => {
     const loop = startProcessingLoop(
       testConfig(),
       createEmptyRegistry(),
-      FAST_LOOP,
+      makeFastLoop(),
     );
     await waitFor(() => getInboxMessage(id1)?.status === "done");
 
@@ -607,7 +638,7 @@ describe("processing loop", () => {
     const loop = startProcessingLoop(
       testConfig(),
       createEmptyRegistry(),
-      FAST_LOOP,
+      makeFastLoop(),
     );
     await waitFor(() => getInboxMessage(idA)?.status === "done");
 
@@ -660,7 +691,7 @@ describe("processing loop", () => {
     const loop = startProcessingLoop(
       testConfig(),
       createEmptyRegistry(),
-      FAST_LOOP,
+      makeFastLoop(),
     );
 
     await waitFor(() => getInboxMessage(eventId)?.status === "done");
@@ -683,7 +714,11 @@ describe("processing loop", () => {
       text: "Hello",
       topicKey: "topic-no-engram",
     });
-    const loop = startProcessingLoop(config, createEmptyRegistry(), FAST_LOOP);
+    const loop = startProcessingLoop(
+      config,
+      createEmptyRegistry(),
+      makeFastLoop(),
+    );
 
     await waitFor(() => getInboxMessage(eventId)?.status === "done");
     await loop.stop();
@@ -711,7 +746,7 @@ describe("processing loop", () => {
     const loop = startProcessingLoop(
       testConfig(),
       createEmptyRegistry(),
-      FAST_LOOP,
+      makeFastLoop(),
     );
 
     await waitFor(() => getInboxMessage(eventId)?.status === "done");
@@ -761,7 +796,11 @@ describe("processing loop", () => {
       text: "Hi there",
       topicKey: "topic-extract",
     });
-    const loop = startProcessingLoop(config, createEmptyRegistry(), FAST_LOOP);
+    const loop = startProcessingLoop(
+      config,
+      createEmptyRegistry(),
+      makeFastLoop(),
+    );
 
     await waitFor(() => getInboxMessage(eventId)?.status === "done");
 
@@ -775,7 +814,7 @@ describe("processing loop", () => {
     // Cursor should be advanced
     const cursor = getExtractionCursor("topic-extract");
     expect(cursor).not.toBeNull();
-    expect(cursor!.turns_since_extraction).toBe(0);
+    expect(cursor.turns_since_extraction).toBe(0);
   });
 
   test("counts turns for extraction even when extraction is in-flight", async () => {
@@ -812,7 +851,11 @@ describe("processing loop", () => {
       text: "Message A",
       topicKey: "topic-inflight",
     });
-    const loop = startProcessingLoop(config, createEmptyRegistry(), FAST_LOOP);
+    const loop = startProcessingLoop(
+      config,
+      createEmptyRegistry(),
+      makeFastLoop(),
+    );
     await waitFor(() => getInboxMessage(idA)?.status === "done");
     // Wait for extraction to start (it will be blocked)
     await waitFor(() => extractionCallCount >= 1);
@@ -889,7 +932,11 @@ describe("processing loop", () => {
       text: "Message A",
       topicKey: "topic-catchup",
     });
-    const loop = startProcessingLoop(config, createEmptyRegistry(), FAST_LOOP);
+    const loop = startProcessingLoop(
+      config,
+      createEmptyRegistry(),
+      makeFastLoop(),
+    );
     await waitFor(() => getInboxMessage(idA)?.status === "done");
     await waitFor(() => extractionCallCount >= 1);
 
@@ -959,7 +1006,11 @@ describe("processing loop", () => {
       externalMessageId: "msg-second-ext",
     });
 
-    const loop = startProcessingLoop(config, createEmptyRegistry(), FAST_LOOP);
+    const loop = startProcessingLoop(
+      config,
+      createEmptyRegistry(),
+      makeFastLoop(),
+    );
 
     await waitFor(() => getInboxMessage(id2)?.status === "done");
     await Bun.sleep(200);
@@ -1009,7 +1060,11 @@ describe("processing loop", () => {
       text: "I want to visit Tokyo",
       topicKey: "topic-summary-e2e",
     });
-    const loop = startProcessingLoop(config, createEmptyRegistry(), FAST_LOOP);
+    const loop = startProcessingLoop(
+      config,
+      createEmptyRegistry(),
+      makeFastLoop(),
+    );
     await waitFor(() => getInboxMessage(id1)?.status === "done");
     // Wait for fire-and-forget extraction + summary to complete
     await waitFor(() => getTopicSummary("topic-summary-e2e") !== null);
@@ -1107,7 +1162,11 @@ describe("processing loop", () => {
       text: "Greet Watson",
       topicKey: "topic-tools",
     });
-    const loop = startProcessingLoop(testConfig(), stubRegistry, FAST_LOOP);
+    const loop = startProcessingLoop(
+      testConfig(),
+      stubRegistry,
+      makeFastLoop(),
+    );
 
     await waitFor(() => getInboxMessage(eventId)?.status === "done");
     await loop.stop();
@@ -1153,6 +1212,7 @@ describe("processing loop", () => {
 
     try {
       initDatabase(tmpDb);
+      stateLoader = new StateLoader(getDatabase());
 
       // Simulate a message stuck in 'processing' from a prior crash
       const { eventId } = ingestMessage({ text: "Stuck message" });
@@ -1163,6 +1223,7 @@ describe("processing loop", () => {
 
       // Re-init the database (simulates a restart) — should recover the message
       initDatabase(tmpDb);
+      stateLoader = new StateLoader(getDatabase());
 
       // The message should be back to 'pending'
       expect(getInboxMessage(eventId)?.status).toBe("pending");
@@ -1171,7 +1232,7 @@ describe("processing loop", () => {
       const loop = startProcessingLoop(
         testConfig(),
         createEmptyRegistry(),
-        FAST_LOOP,
+        makeFastLoop(),
       );
 
       await waitFor(() => getInboxMessage(eventId)?.status === "done");
@@ -1182,6 +1243,7 @@ describe("processing loop", () => {
       expect(outbox).toHaveLength(1);
       expect(outbox[0].text).toBe("Recovered!");
     } finally {
+      await stateLoader.flush();
       closeDatabase();
       unlinkSync(tmpDb);
     }

--- a/test/receptor-cursors.test.ts
+++ b/test/receptor-cursors.test.ts
@@ -1,18 +1,42 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import {
-  closeDatabase,
-  getReceptorCursor,
-  initDatabase,
-  upsertReceptorCursor,
-} from "../src/db";
+import { closeDatabase, getDatabase, initDatabase } from "../src/db";
+import { ReceptorCursorState, StateLoader } from "../src/state";
+
+let stateLoader: StateLoader;
 
 beforeEach(() => {
   initDatabase(":memory:");
+  stateLoader = new StateLoader(getDatabase());
 });
 
-afterEach(() => {
+afterEach(async () => {
+  await stateLoader.flush();
   closeDatabase();
 });
+
+function getReceptorCursor(channel: string): {
+  cursorValue: string | null;
+  lastSyncedAt: number | null;
+} | null {
+  const state = stateLoader.load(ReceptorCursorState, channel);
+  if (state.cursorValue === null && state.lastSyncedAt === null) {
+    return null;
+  }
+  return {
+    cursorValue: state.cursorValue,
+    lastSyncedAt: state.lastSyncedAt?.getTime() ?? null,
+  };
+}
+
+async function upsertReceptorCursor(
+  channel: string,
+  cursorValue: string,
+): Promise<void> {
+  const state = stateLoader.load(ReceptorCursorState, channel);
+  state.cursorValue = cursorValue;
+  state.lastSyncedAt = new Date();
+  await stateLoader.flush();
+}
 
 describe("receptor cursors", () => {
   test("getReceptorCursor returns null when no cursor exists", () => {
@@ -20,17 +44,17 @@ describe("receptor cursors", () => {
     expect(cursor).toBeNull();
   });
 
-  test("upsertReceptorCursor creates new cursor", () => {
-    upsertReceptorCursor("telegram", "12345");
+  test("upsertReceptorCursor creates new cursor", async () => {
+    await upsertReceptorCursor("telegram", "12345");
 
     const cursor = getReceptorCursor("telegram");
     expect(cursor).not.toBeNull();
     expect(cursor!.cursorValue).toBe("12345");
   });
 
-  test("getReceptorCursor returns cursor with cursorValue and lastSyncedAt", () => {
+  test("getReceptorCursor returns cursor with cursorValue and lastSyncedAt", async () => {
     const before = Date.now();
-    upsertReceptorCursor("calendar", "2026-02-22T00:00:00Z");
+    await upsertReceptorCursor("calendar", "2026-02-22T00:00:00Z");
     const after = Date.now();
 
     const cursor = getReceptorCursor("calendar");
@@ -40,20 +64,20 @@ describe("receptor cursors", () => {
     expect(cursor!.lastSyncedAt).toBeLessThanOrEqual(after);
   });
 
-  test("upsertReceptorCursor updates existing cursor (upsert behavior)", () => {
-    upsertReceptorCursor("telegram", "100");
+  test("upsertReceptorCursor updates existing cursor (upsert behavior)", async () => {
+    await upsertReceptorCursor("telegram", "100");
     const first = getReceptorCursor("telegram");
     expect(first!.cursorValue).toBe("100");
 
-    upsertReceptorCursor("telegram", "200");
+    await upsertReceptorCursor("telegram", "200");
     const second = getReceptorCursor("telegram");
     expect(second!.cursorValue).toBe("200");
-    expect(second!.lastSyncedAt).toBeGreaterThanOrEqual(first!.lastSyncedAt);
+    expect(second!.lastSyncedAt).toBeGreaterThanOrEqual(first!.lastSyncedAt!);
   });
 
-  test("cursors for different channels are independent", () => {
-    upsertReceptorCursor("telegram", "999");
-    upsertReceptorCursor("calendar", "abc");
+  test("cursors for different channels are independent", async () => {
+    await upsertReceptorCursor("telegram", "999");
+    await upsertReceptorCursor("calendar", "abc");
 
     expect(getReceptorCursor("telegram")!.cursorValue).toBe("999");
     expect(getReceptorCursor("calendar")!.cursorValue).toBe("abc");

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -19,7 +19,6 @@ import {
   initDatabase,
   insertReceptorBuffer,
   resetDatabase,
-  upsertReceptorCursor,
 } from "../src/db";
 import { startServer } from "../src/server";
 

--- a/test/thalamus.test.ts
+++ b/test/thalamus.test.ts
@@ -11,16 +11,32 @@ import {
   claimNextInboxMessage,
   closeDatabase,
   getDatabase,
-  getReceptorCursor,
   getUnprocessedBuffers,
   initDatabase,
   insertReceptorBuffer,
 } from "../src/db";
+import { ReceptorCursorState, StateLoader, ThalamusState } from "../src/state";
 import {
   type ReceivePayload,
   Thalamus,
   type ThalamusConfig,
 } from "../src/thalamus";
+
+let stateLoader: StateLoader;
+
+function getReceptorCursor(channel: string): {
+  cursorValue: string | null;
+  lastSyncedAt: number | null;
+} | null {
+  const state = stateLoader.load(ReceptorCursorState, channel);
+  if (state.cursorValue === null && state.lastSyncedAt === null) {
+    return null;
+  }
+  return {
+    cursorValue: state.cursorValue,
+    lastSyncedAt: state.lastSyncedAt?.getTime() ?? null,
+  };
+}
 
 function makePayload(overrides?: Partial<ReceivePayload>): ReceivePayload {
   return {
@@ -37,10 +53,12 @@ describe("thalamus.receive()", () => {
 
   beforeEach(() => {
     initDatabase(":memory:");
+    stateLoader = new StateLoader(getDatabase());
     thalamus = new Thalamus();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await stateLoader.flush();
     closeDatabase();
   });
 
@@ -371,9 +389,11 @@ function makeThalamusConfig(
 describe("thalamus.syncAll()", () => {
   beforeEach(() => {
     initDatabase(":memory:");
+    stateLoader = new StateLoader(getDatabase());
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await stateLoader.flush();
     closeDatabase();
   });
 
@@ -516,7 +536,9 @@ describe("thalamus.syncAll()", () => {
     mockSynapseHandler = () => Response.json(makeSynapseResponse([]));
 
     const thalamus = new Thalamus(makeThalamusConfig());
+    thalamus.setStateLoader(stateLoader);
     await thalamus.syncAll();
+    await stateLoader.flush();
 
     const calCursor = getReceptorCursor("calendar");
     expect(calCursor).not.toBeNull();
@@ -840,9 +862,11 @@ describe("thalamus.syncChannel()", () => {
 describe("thalamus.start()", () => {
   beforeEach(() => {
     initDatabase(":memory:");
+    stateLoader = new StateLoader(getDatabase());
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await stateLoader.flush();
     closeDatabase();
   });
 
@@ -903,6 +927,7 @@ describe("thalamus.start()", () => {
     mockSynapseHandler = () => Response.json(makeSynapseResponse([]));
 
     const thalamus = new Thalamus(makeThalamusConfig());
+    thalamus.setStateLoader(stateLoader);
     expect(thalamus.getLastSyncAt()).toBeNull();
 
     await thalamus.start();


### PR DESCRIPTION
## Summary
- Migrated extraction cursors, topic summaries, receptor cursors, and thalamus state to use @Persisted state abstraction from @shetty4l/core
- Removed 7 CRUD functions and 3 schema definitions from db.ts (~170 lines removed)
- Added 4 state classes in src/state/ directory with proper decorators and field types
- StateLoader is now initialized in index.ts and passed through to extraction.ts and thalamus/index.ts
- stateLoader.flush() called in shutdown path for clean persistence

Closes #91

## Commits
1. refactor: migrate state tables to @Persisted abstraction

## Validation
All 496 tests pass. Typecheck, lint, and format checks pass.