### PR TITLE
feat: approval gate for mutating tools

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -12,11 +12,19 @@
  * - Per-tool timeout via Promise.race with config.toolTimeoutMs
  * - Tool errors are returned to the model as structured results, not thrown
  * - SkillRuntimeContext.db is deferred (undefined for now)
+ * - Mutating tools require approval before execution
  */
 
 import { createLogger } from "@shetty4l/core/log";
 import type { Result } from "@shetty4l/core/result";
 import { err, ok } from "@shetty4l/core/result";
+import type { StateLoader } from "@shetty4l/core/state";
+import {
+  consumeApproval,
+  getApprovalForTool,
+  isExpired,
+  proposeApproval,
+} from "./approval";
 import { getDebugLogger } from "./debug-logger";
 import type { SkillRegistry, SkillRuntimeContext } from "./skills";
 import type { ChatMessage, OpenAITool, ToolCall } from "./synapse";
@@ -41,6 +49,12 @@ export interface AgentResult {
   response: string;
   /** All NEW assistant+tool messages from the loop (for history). */
   turns: ChatMessage[];
+  /** If set, the agent is blocked waiting for approval. */
+  needsApproval?: boolean;
+  /** The approval ID if needsApproval is true. */
+  approvalId?: string;
+  /** The tool calls blocked pending approval. */
+  blockedToolCalls?: ToolCall[];
 }
 
 // --- Loop ---
@@ -53,6 +67,10 @@ export interface AgentResult {
  * and loops. Continues until the model produces a text response without
  * tool calls or the max rounds are exhausted.
  *
+ * If any requested tool is mutating, the loop blocks and returns a
+ * needsApproval result. The caller must handle the approval flow and
+ * resume execution by calling runAgentLoop again with the approved state.
+ *
  * Returns all new messages generated during the loop (assistant + tool)
  * for the caller to persist to history.
  */
@@ -61,11 +79,39 @@ export async function runAgentLoop(opts: {
   tools: OpenAITool[];
   registry: SkillRegistry;
   config: AgentConfig;
+  /** StateLoader for approval persistence (optional for backward compatibility) */
+  stateLoader?: StateLoader;
+  /** Topic key for approval scoping (required if stateLoader is provided) */
+  topicKey?: string;
+  /**
+   * Tool calls to execute immediately without calling the LLM first.
+   * Used when resuming from an approved approval to execute the blocked tools.
+   */
+  resumeToolCalls?: ToolCall[];
 }): Promise<Result<AgentResult>> {
-  const { tools, registry, config } = opts;
+  const { tools, registry, config, stateLoader, topicKey, resumeToolCalls } =
+    opts;
   const messages = [...opts.messages]; // Don't mutate caller's array
   const newTurns: ChatMessage[] = [];
   let rounds = 0;
+
+  // If resuming with tool calls, execute them first before entering the loop
+  if (resumeToolCalls && resumeToolCalls.length > 0) {
+    // Execute the resumed tool calls directly (approval already granted)
+    const toolResults = await executeToolCalls(
+      resumeToolCalls,
+      registry,
+      config,
+    );
+
+    // Append tool results
+    for (const toolMsg of toolResults) {
+      messages.push(toolMsg);
+      newTurns.push(toolMsg);
+    }
+
+    rounds++;
+  }
 
   while (true) {
     // Call LLM
@@ -98,6 +144,32 @@ export async function runAgentLoop(opts: {
     messages.push(assistantMsg);
     newTurns.push(assistantMsg);
 
+    // Check if any tool is mutating — if so, we need approval
+    const hasMutating = response.toolCalls.some((tc) =>
+      registry.isMutating(tc.function.name),
+    );
+
+    if (hasMutating && stateLoader && topicKey) {
+      // Check for existing approved approval for these tools
+      const approvalResult = await checkAndConsumeApproval(
+        response.toolCalls,
+        registry,
+        stateLoader,
+        topicKey,
+        messages,
+        newTurns,
+        config,
+      );
+
+      if (approvalResult.needsApproval) {
+        // Create new approval and return blocked state
+        return ok(approvalResult);
+      }
+
+      // Approval was consumed, execute the tools normally
+      // (toolResults are already in approvalResult.toolResults if consumed)
+    }
+
     // Execute all tool calls in parallel
     const toolResults = await executeToolCalls(
       response.toolCalls,
@@ -122,6 +194,82 @@ export async function runAgentLoop(opts: {
       return ok({ response: fallback, turns: newTurns });
     }
   }
+}
+
+// --- Approval check ---
+
+/**
+ * Check if we have an approved (and not expired) approval for the mutating tools.
+ * If approved, consume it and return needsApproval: false.
+ * If not approved or no approval exists, create a new pending approval and return
+ * needsApproval: true with the approval details.
+ */
+async function checkAndConsumeApproval(
+  toolCalls: ToolCall[],
+  registry: SkillRegistry,
+  stateLoader: StateLoader,
+  topicKey: string,
+  messages: ChatMessage[],
+  newTurns: ChatMessage[],
+  _config: AgentConfig,
+): Promise<AgentResult> {
+  // Find the first mutating tool for approval lookup
+  const mutatingToolCall = toolCalls.find((tc) =>
+    registry.isMutating(tc.function.name),
+  );
+
+  if (!mutatingToolCall) {
+    // No mutating tool (shouldn't happen if we get here, but be safe)
+    return { response: "", turns: newTurns, needsApproval: false };
+  }
+
+  const toolName = mutatingToolCall.function.name;
+
+  // Check for existing approved approval
+  const existingApproval = getApprovalForTool(stateLoader, topicKey, toolName);
+
+  if (existingApproval && !isExpired(existingApproval)) {
+    // Consume the approval and allow execution
+    await consumeApproval(stateLoader, existingApproval.id);
+    return { response: "", turns: newTurns, needsApproval: false };
+  }
+
+  // No valid approval — create a new pending approval
+  // Serialize the current state for resumption
+  const agentStateJson = JSON.stringify(messages);
+  const toolCallsJson = JSON.stringify(toolCalls);
+
+  // Build tool description for the approval action
+  const toolDescriptions = toolCalls
+    .filter((tc) => registry.isMutating(tc.function.name))
+    .map((tc) => {
+      try {
+        const args = JSON.parse(tc.function.arguments);
+        return `${tc.function.name}(${JSON.stringify(args)})`;
+      } catch {
+        return `${tc.function.name}(${tc.function.arguments})`;
+      }
+    })
+    .join(", ");
+
+  const approval = proposeApproval(stateLoader, {
+    topicKey,
+    action: `execute: ${toolDescriptions}`,
+    toolName,
+    toolArgsJson: mutatingToolCall.function.arguments,
+    agentStateJson,
+    toolCallsJson,
+  });
+
+  log(`[${topicKey}] approval required for ${toolName}: ${approval.id}`);
+
+  return {
+    response: "",
+    turns: newTurns,
+    needsApproval: true,
+    approvalId: approval.id,
+    blockedToolCalls: toolCalls,
+  };
 }
 
 // --- Helpers ---

--- a/src/approval/entity.ts
+++ b/src/approval/entity.ts
@@ -30,6 +30,12 @@ export class PendingApproval extends CollectionEntity {
   @Field("string") @Index() status: ApprovalStatus = "pending";
   @Field("number") @Index() proposedAt: number = 0;
   @Field("number") resolvedAt: number | null = null;
+  /** Serialized agent state (messages array) for resumption after approval */
+  @Field("string") agentStateJson: string | null = null;
+  /** Serialized tool calls blocked pending approval */
+  @Field("string") toolCallsJson: string | null = null;
+  /** Timestamp when this approval expires (proposedAt + TTL) */
+  @Field("number") @Index() expiresAt: number = 0;
 
   async save(): Promise<void> {
     throw new Error("Not bound to StateLoader");

--- a/src/approval/index.ts
+++ b/src/approval/index.ts
@@ -12,11 +12,28 @@ import type { ApprovalStatus } from "./types";
 export { PendingApproval } from "./entity";
 export type { ApprovalStatus } from "./types";
 
+/** Approval time-to-live: 15 minutes */
+export const APPROVAL_TTL_MS = 15 * 60 * 1000;
+
 export interface ProposeApprovalInput {
   topicKey: string;
   action: string;
   toolName?: string;
   toolArgsJson?: string;
+  /** Serialized agent state (messages array) for resumption */
+  agentStateJson?: string;
+  /** Serialized tool calls blocked pending approval */
+  toolCallsJson?: string;
+}
+
+/**
+ * Check if an approval has expired based on its expiresAt timestamp.
+ */
+export function isExpired(
+  approval: PendingApproval,
+  now = Date.now(),
+): boolean {
+  return approval.expiresAt > 0 && now >= approval.expiresAt;
 }
 
 /**
@@ -36,6 +53,9 @@ export function proposeApproval(
     status: "pending" as ApprovalStatus,
     proposedAt: now,
     resolvedAt: null,
+    agentStateJson: input.agentStateJson ?? null,
+    toolCallsJson: input.toolCallsJson ?? null,
+    expiresAt: now + APPROVAL_TTL_MS,
   });
 }
 

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -3,19 +3,28 @@
  *
  * Polls the inbox for pending messages and processes them sequentially:
  *   1. Claim the oldest pending inbox message
- *   2. Recall relevant memories from Engram (topic-scoped + global)
- *   3. Load recent turn history from SQLite
- *   4. Load topic summary from SQLite (if available)
- *   5. Build prompt (system + memories + summary + history + user message)
- *   6. Call Synapse (plain chat or agent loop with tools)
- *   7. Save turns to history
- *   8. Trigger async fact extraction + summary update (fire-and-forget)
- *   9. Write the assistant response to the outbox
- *  10. Mark the inbox message as done (or failed on error)
+ *   2. Check for pending approvals - block new messages if approval pending
+ *   3. Handle approval_response messages specially
+ *   4. Recall relevant memories from Engram (topic-scoped + global)
+ *   5. Load recent turn history from SQLite
+ *   6. Load topic summary from SQLite (if available)
+ *   7. Build prompt (system + memories + summary + history + user message)
+ *   8. Call Synapse (plain chat or agent loop with tools)
+ *   9. If agent returns needsApproval, send approval request with buttons
+ *  10. Save turns to history
+ *  11. Trigger async fact extraction + summary update (fire-and-forget)
+ *  12. Write the assistant response to the outbox
+ *  13. Mark the inbox message as done (or failed on error)
  */
 
 import { createLogger } from "@shetty4l/core/log";
 import { runAgentLoop } from "./agent";
+import {
+  isExpired,
+  listPendingApprovals,
+  PendingApproval,
+  resolveApproval,
+} from "./approval";
 import type { CortexConfig } from "./config";
 import { getDatabase } from "./db";
 import { getDebugLogger } from "./debug-logger";
@@ -40,7 +49,7 @@ import {
   StateLoader,
   TopicSummaryState,
 } from "./state";
-import type { OpenAITool } from "./synapse";
+import type { ChatMessage, OpenAITool, ToolCall } from "./synapse";
 import { chat } from "./synapse";
 import type { BuiltinToolContext } from "./tools";
 import { resolveOutputChannel } from "./tools";
@@ -194,6 +203,109 @@ export function startProcessingLoop(
               });
             }
 
+            // Handle approval_response messages specially
+            const metadata = message.metadata_json
+              ? (JSON.parse(message.metadata_json) as Record<string, unknown>)
+              : null;
+            if (metadata?.type === "approval_response") {
+              const approvalId = metadata.approvalId as string;
+              const action = metadata.action as "approve" | "reject";
+
+              log(
+                `[${message.topic_key}] approval response: ${approvalId} -> ${action}`,
+              );
+
+              const result = await handleApprovalResponse(
+                stateLoader,
+                approvalId,
+                action,
+                config,
+                registry,
+                openAITools,
+              );
+
+              if (result) {
+                // Save turns to history if any
+                if (result.turns.length > 0) {
+                  await saveAgentHistoryWithLoader(
+                    stateLoader,
+                    message.topic_key,
+                    result.turns,
+                  );
+                }
+
+                // Enqueue response to outbox
+                enqueueOutboxMessage(stateLoader, {
+                  channel: resolveOutputChannel(message.channel, config),
+                  topicKey: message.topic_key,
+                  text: result.response,
+                });
+              }
+
+              const processingMs = Math.round(performance.now() - startMs);
+              await completeInboxMessage(stateLoader, message.id, processingMs);
+
+              if (debug.isEnabled()) {
+                debug.log({
+                  type: "done",
+                  traceId,
+                  timestamp: new Date().toISOString(),
+                  totalMs: processingMs,
+                  ok: true,
+                  approvalId,
+                  action,
+                });
+              }
+
+              return; // Exit trace context, continue loop
+            }
+
+            // Check for pending approvals - block new messages if approval pending
+            const pendingApprovals = listPendingApprovals(
+              stateLoader,
+              message.topic_key,
+            );
+            if (pendingApprovals.length > 0) {
+              const approval = pendingApprovals[0]; // Most recent
+
+              if (!isExpired(approval)) {
+                // Re-present approval buttons
+                log(
+                  `[${message.topic_key}] blocked by pending approval: ${approval.id}`,
+                );
+
+                enqueueOutboxMessage(stateLoader, {
+                  channel: resolveOutputChannel(message.channel, config),
+                  topicKey: message.topic_key,
+                  text: "Please respond to the pending approval request first.",
+                  payload: {
+                    buttons: [
+                      {
+                        text: "✓ Approve",
+                        callback_data: `approval:${approval.id}:approve`,
+                      },
+                      {
+                        text: "✗ Reject",
+                        callback_data: `approval:${approval.id}:reject`,
+                      },
+                    ],
+                  },
+                });
+
+                // Mark inbox message as done (we handled it by re-presenting)
+                const processingMs = Math.round(performance.now() - startMs);
+                await completeInboxMessage(
+                  stateLoader,
+                  message.id,
+                  processingMs,
+                );
+                return; // Exit the trace context, continue loop
+              }
+
+              // Approval expired - resolve it and continue processing
+              await resolveApproval(stateLoader, approval.id, "expired");
+            }
+
             // 1. Recall memories from Engram (graceful on failure)
             const memories = await recallDual(
               message.text,
@@ -264,6 +376,9 @@ export function startProcessingLoop(
             let responseText: string;
             let ok: boolean;
             let errorMsg: string | undefined;
+            let needsApproval = false;
+            let approvalId: string | undefined;
+            let blockedToolCalls: ToolCall[] | undefined;
 
             if (hasTools) {
               const agentResult = await runAgentLoop({
@@ -278,22 +393,46 @@ export function startProcessingLoop(
                   skillConfig: config.skillConfig,
                   synapseTimeoutMs: config.synapseTimeoutMs,
                 },
+                stateLoader,
+                topicKey: message.topic_key,
               });
 
               if (agentResult.ok) {
-                ok = true;
-                responseText = agentResult.value.response;
+                // Check if agent needs approval
+                if (agentResult.value.needsApproval) {
+                  needsApproval = true;
+                  approvalId = agentResult.value.approvalId;
+                  blockedToolCalls = agentResult.value.blockedToolCalls;
+                  ok = true;
+                  responseText = "";
 
-                // Save full agent history (user message + all loop turns)
-                const userMessage = {
-                  role: "user" as const,
-                  content: message.text,
-                };
-                await saveAgentHistoryWithLoader(
-                  stateLoader,
-                  message.topic_key,
-                  [userMessage, ...agentResult.value.turns],
-                );
+                  // Save partial history (up to where we blocked)
+                  if (agentResult.value.turns.length > 0) {
+                    const userMessage = {
+                      role: "user" as const,
+                      content: message.text,
+                    };
+                    await saveAgentHistoryWithLoader(
+                      stateLoader,
+                      message.topic_key,
+                      [userMessage, ...agentResult.value.turns],
+                    );
+                  }
+                } else {
+                  ok = true;
+                  responseText = agentResult.value.response;
+
+                  // Save full agent history (user message + all loop turns)
+                  const userMessage = {
+                    role: "user" as const,
+                    content: message.text,
+                  };
+                  await saveAgentHistoryWithLoader(
+                    stateLoader,
+                    message.topic_key,
+                    [userMessage, ...agentResult.value.turns],
+                  );
+                }
               } else {
                 ok = false;
                 responseText = "";
@@ -328,55 +467,111 @@ export function startProcessingLoop(
             const processingMs = Math.round(performance.now() - startMs);
 
             if (ok) {
-              // 7. Trigger async extraction (fire-and-forget, serialized per topic)
-              //    Always increment the turn counter — even when extraction is
-              //    already in-flight — so the cadence stays accurate.
-              if (config.extractionModels && stateLoader) {
-                const cursor = stateLoader.load(
-                  ExtractionCursorState,
-                  message.topic_key,
+              // Handle approval request case
+              if (needsApproval && approvalId && blockedToolCalls) {
+                // Generate approval request message with buttons
+                const approvalMessage = await generateApprovalMessage(
+                  blockedToolCalls,
+                  registry,
+                  config,
                 );
-                cursor.turnsSinceExtraction += 1;
-                // Flush immediately so maybeExtract sees the updated counter
-                await stateLoader.flush();
-              }
-              if (stateLoader && !extractionInFlight.has(message.topic_key)) {
-                const p = maybeExtract(message.topic_key, config, stateLoader)
-                  .catch((e) =>
-                    log(
-                      `[${message.topic_key}] extraction error: ${e instanceof Error ? e.message : String(e)}`,
-                    ),
-                  )
-                  .finally(() => extractionInFlight.delete(message.topic_key));
-                extractionInFlight.set(message.topic_key, p);
-              }
 
-              // 8. Write to outbox
-              enqueueOutboxMessage(stateLoader, {
-                channel: resolveOutputChannel(message.channel, config),
-                topicKey: message.topic_key,
-                text: responseText,
-              });
-
-              await completeInboxMessage(stateLoader, message.id, processingMs);
-
-              const responsePreview =
-                responseText.length > 120
-                  ? `${responseText.slice(0, 117)}...`
-                  : responseText;
-              log(
-                `[${message.topic_key}] done in ${elapsed}s: ${responsePreview}`,
-              );
-
-              // Emit done event
-              if (debug.isEnabled()) {
-                debug.log({
-                  type: "done",
-                  traceId,
-                  timestamp: new Date().toISOString(),
-                  totalMs: processingMs,
-                  ok: true,
+                // Enqueue approval request to outbox with buttons
+                enqueueOutboxMessage(stateLoader, {
+                  channel: resolveOutputChannel(message.channel, config),
+                  topicKey: message.topic_key,
+                  text: approvalMessage,
+                  payload: {
+                    buttons: [
+                      {
+                        text: "✓ Approve",
+                        callback_data: `approval:${approvalId}:approve`,
+                      },
+                      {
+                        text: "✗ Reject",
+                        callback_data: `approval:${approvalId}:reject`,
+                      },
+                    ],
+                  },
                 });
+
+                await completeInboxMessage(
+                  stateLoader,
+                  message.id,
+                  processingMs,
+                );
+
+                log(`[${message.topic_key}] approval required: ${approvalId}`);
+
+                // Emit done event
+                if (debug.isEnabled()) {
+                  debug.log({
+                    type: "done",
+                    traceId,
+                    timestamp: new Date().toISOString(),
+                    totalMs: processingMs,
+                    ok: true,
+                    approvalId,
+                  });
+                }
+              } else {
+                // Normal success path
+                // 7. Trigger async extraction (fire-and-forget, serialized per topic)
+                //    Always increment the turn counter — even when extraction is
+                //    already in-flight — so the cadence stays accurate.
+                if (config.extractionModels && stateLoader) {
+                  const cursor = stateLoader.load(
+                    ExtractionCursorState,
+                    message.topic_key,
+                  );
+                  cursor.turnsSinceExtraction += 1;
+                  // Flush immediately so maybeExtract sees the updated counter
+                  await stateLoader.flush();
+                }
+                if (stateLoader && !extractionInFlight.has(message.topic_key)) {
+                  const p = maybeExtract(message.topic_key, config, stateLoader)
+                    .catch((e) =>
+                      log(
+                        `[${message.topic_key}] extraction error: ${e instanceof Error ? e.message : String(e)}`,
+                      ),
+                    )
+                    .finally(() =>
+                      extractionInFlight.delete(message.topic_key),
+                    );
+                  extractionInFlight.set(message.topic_key, p);
+                }
+
+                // 8. Write to outbox
+                enqueueOutboxMessage(stateLoader, {
+                  channel: resolveOutputChannel(message.channel, config),
+                  topicKey: message.topic_key,
+                  text: responseText,
+                });
+
+                await completeInboxMessage(
+                  stateLoader,
+                  message.id,
+                  processingMs,
+                );
+
+                const responsePreview =
+                  responseText.length > 120
+                    ? `${responseText.slice(0, 117)}...`
+                    : responseText;
+                log(
+                  `[${message.topic_key}] done in ${elapsed}s: ${responsePreview}`,
+                );
+
+                // Emit done event
+                if (debug.isEnabled()) {
+                  debug.log({
+                    type: "done",
+                    traceId,
+                    timestamp: new Date().toISOString(),
+                    totalMs: processingMs,
+                    ok: true,
+                  });
+                }
               }
             } else {
               log(`[${message.topic_key}] failed in ${elapsed}s: ${errorMsg}`);
@@ -432,4 +627,160 @@ export function startProcessingLoop(
       await done;
     },
   };
+}
+
+// --- Approval helpers ---
+
+/**
+ * Generate an approval request message describing the blocked tools.
+ * Uses the LLM without tools to generate a human-readable approval prompt.
+ */
+async function generateApprovalMessage(
+  blockedToolCalls: ToolCall[],
+  _registry: SkillRegistry,
+  config: CortexConfig,
+): Promise<string> {
+  // Build tool descriptions for the approval message
+  const toolDescriptions = blockedToolCalls
+    .map((tc) => {
+      const name = tc.function.name;
+      let argsDisplay: string;
+      try {
+        const args = JSON.parse(tc.function.arguments);
+        argsDisplay = JSON.stringify(args, null, 2);
+      } catch {
+        argsDisplay = tc.function.arguments;
+      }
+      return `**${name}**\n\`\`\`json\n${argsDisplay}\n\`\`\``;
+    })
+    .join("\n\n");
+
+  // Create a prompt for the LLM to generate an approval message
+  const approvalPromptMessages: ChatMessage[] = [
+    {
+      role: "system",
+      content: `You are an assistant helping a user approve or reject a tool execution request.
+Generate a brief, clear message explaining what action is about to be taken and asking for approval.
+Be concise but informative. The user will see Approve/Reject buttons below your message.
+Do not include the buttons in your response - they will be added automatically.`,
+    },
+    {
+      role: "user",
+      content: `The following tool(s) require approval before execution:\n\n${toolDescriptions}\n\nGenerate an approval request message.`,
+    },
+  ];
+
+  // Call LLM without tools to generate approval message
+  const result = await chat(
+    approvalPromptMessages,
+    config.models,
+    config.synapseUrl,
+    { timeoutMs: config.synapseTimeoutMs },
+  );
+
+  if (result.ok) {
+    return result.value.content;
+  }
+
+  // Fallback to a simple message if LLM fails
+  const toolNames = blockedToolCalls.map((tc) => tc.function.name).join(", ");
+  return `The following action requires your approval: **${toolNames}**\n\nPlease review and approve or reject.`;
+}
+
+/**
+ * Handle an approval response (approve/reject callback from button click).
+ * Returns the response text to send to the user, or null if the approval
+ * should be handled by resuming the agent loop.
+ */
+export async function handleApprovalResponse(
+  stateLoader: IStateLoader,
+  approvalId: string,
+  action: "approve" | "reject",
+  config: CortexConfig,
+  registry: SkillRegistry,
+  openAITools: OpenAITool[],
+): Promise<{ response: string; turns: ChatMessage[] } | null> {
+  const approval = stateLoader.get(PendingApproval, approvalId);
+
+  if (!approval) {
+    return {
+      response:
+        "This approval request was not found or has already been processed.",
+      turns: [],
+    };
+  }
+
+  if (approval.status !== "pending") {
+    return {
+      response: "This approval request has already been processed.",
+      turns: [],
+    };
+  }
+
+  if (isExpired(approval)) {
+    await resolveApproval(stateLoader, approvalId, "expired");
+    return {
+      response:
+        "This approval request has expired. Please try your request again.",
+      turns: [],
+    };
+  }
+
+  if (action === "reject") {
+    await resolveApproval(stateLoader, approvalId, "rejected");
+    return { response: "Action cancelled.", turns: [] };
+  }
+
+  // Approve: mark as approved and resume agent loop
+  await resolveApproval(stateLoader, approvalId, "approved");
+
+  // Deserialize state and resume
+  if (!approval.agentStateJson || !approval.toolCallsJson) {
+    return { response: "Unable to resume: missing state data.", turns: [] };
+  }
+
+  try {
+    const messages = JSON.parse(approval.agentStateJson) as ChatMessage[];
+    const toolCalls = JSON.parse(approval.toolCallsJson) as ToolCall[];
+
+    // Resume the agent loop with the restored state and execute blocked tools directly
+    const agentResult = await runAgentLoop({
+      messages,
+      tools: openAITools,
+      registry,
+      config: {
+        models: config.models,
+        synapseUrl: config.synapseUrl,
+        toolTimeoutMs: config.toolTimeoutMs,
+        maxToolRounds: config.maxToolRounds,
+        skillConfig: config.skillConfig,
+        synapseTimeoutMs: config.synapseTimeoutMs,
+      },
+      stateLoader,
+      topicKey: approval.topicKey,
+      resumeToolCalls: toolCalls,
+    });
+
+    if (agentResult.ok) {
+      if (agentResult.value.needsApproval) {
+        // Shouldn't happen since we just approved, but handle gracefully
+        return {
+          response: "Additional approval required.",
+          turns: agentResult.value.turns,
+        };
+      }
+      return {
+        response: agentResult.value.response,
+        turns: agentResult.value.turns,
+      };
+    }
+
+    return {
+      response: `Error executing action: ${agentResult.error}`,
+      turns: [],
+    };
+  } catch (e) {
+    const errorMsg = e instanceof Error ? e.message : String(e);
+    return { response: `Error resuming action: ${errorMsg}`, turns: [] };
+  }
 }

--- a/src/stats/index.ts
+++ b/src/stats/index.ts
@@ -58,7 +58,7 @@ function percentile(sorted: number[], p: number): number {
  * Get aggregated stats for the /stats API endpoint.
  *
  * Returns inbox/outbox counts, receptor sync timestamps, and processing latency percentiles.
- * Time-based metrics use a 24-hour sliding window via the auto-managed `updated_at` field.
+ * Time-based metrics use a 24-hour sliding window based on message timestamps.
  *
  * Uses StateLoader.count() for counts and StateLoader.find() + JS for percentiles.
  */
@@ -66,7 +66,7 @@ export function getStats(
   stateLoader: StateLoader,
   thalamus?: ThalamusSyncInfo,
 ): CortexStats {
-  const oneDayAgo = new Date(Date.now() - 86_400_000);
+  const oneDayAgoMs = Date.now() - 86_400_000;
 
   // --- Inbox stats ---
   // Pending/processing: all time
@@ -75,18 +75,18 @@ export function getStats(
     status: "processing",
   });
 
-  // Done/failed: last 24h using updated_at filter
+  // Done/failed: last 24h using occurred_at filter
   const inboxDone24h = stateLoader
     .find(InboxMessage, {
       where: { status: "done" },
     })
-    .filter((m) => m.updated_at >= oneDayAgo).length;
+    .filter((m) => m.occurred_at >= oneDayAgoMs).length;
 
   const inboxFailed24h = stateLoader
     .find(InboxMessage, {
       where: { status: "failed" },
     })
-    .filter((m) => m.updated_at >= oneDayAgo).length;
+    .filter((m) => m.occurred_at >= oneDayAgoMs).length;
 
   // --- Outbox stats ---
   const outboxPending = stateLoader.count(OutboxMessage, { status: "pending" });
@@ -96,7 +96,7 @@ export function getStats(
     .find(OutboxMessage, {
       where: { status: "delivered" },
     })
-    .filter((m) => m.updated_at >= oneDayAgo).length;
+    .filter((m) => m.created_at_ms >= oneDayAgoMs).length;
 
   // --- Receptor buffer stats ---
   const bufferPendingTotal = stateLoader.count(ReceptorBuffer, {});
@@ -107,7 +107,7 @@ export function getStats(
     .find(InboxMessage, {
       where: { status: "done" },
     })
-    .filter((m) => m.updated_at >= oneDayAgo && m.processing_ms !== null);
+    .filter((m) => m.occurred_at >= oneDayAgoMs && m.processing_ms !== null);
 
   const latencies = doneWithLatency
     .map((m) => m.processing_ms as number)

--- a/test/approval-gate.test.ts
+++ b/test/approval-gate.test.ts
@@ -1,0 +1,748 @@
+/**
+ * Approval gate integration tests.
+ *
+ * Tests the end-to-end approval flow for mutating tools:
+ * - Non-mutating tools execute immediately
+ * - Mutating tools block and create approval request
+ * - Approved approvals execute blocked tools
+ * - Rejected approvals cancel execution
+ * - Expired approvals return error
+ * - State serialization/deserialization works
+ * - Pending approvals block new messages
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { ok } from "@shetty4l/core/result";
+import { StateLoader } from "@shetty4l/core/state";
+import { runAgentLoop } from "../src/agent";
+import {
+  APPROVAL_TTL_MS,
+  getApprovalForTool,
+  isExpired,
+  listPendingApprovals,
+  PendingApproval,
+  proposeApproval,
+  resolveApproval,
+} from "../src/approval";
+import type { CortexConfig } from "../src/config";
+import { closeDatabase, getDatabase, initDatabase } from "../src/db";
+import { enqueueInboxMessage, getInboxMessage } from "../src/inbox";
+import { handleApprovalResponse, startProcessingLoop } from "../src/loop";
+import { listOutboxMessagesByTopic } from "../src/outbox";
+import type { SkillRegistry, SkillToolResult } from "../src/skills";
+import type { OpenAITool } from "../src/synapse";
+
+let stateLoader: StateLoader;
+
+// --- Mock Synapse server ---
+
+let mockSynapse: ReturnType<typeof Bun.serve>;
+let mockSynapseUrl: string;
+let mockSynapseHandler: (req: Request) => Response | Promise<Response>;
+
+beforeAll(() => {
+  mockSynapseHandler = () =>
+    Response.json({ error: "no mock configured" }, { status: 500 });
+
+  mockSynapse = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req) {
+      return mockSynapseHandler(req);
+    },
+  });
+
+  mockSynapseUrl = `http://127.0.0.1:${mockSynapse.port}`;
+});
+
+afterAll(() => {
+  mockSynapse.stop(true);
+});
+
+beforeEach(() => {
+  initDatabase(":memory:");
+  stateLoader = new StateLoader(getDatabase());
+});
+
+afterEach(async () => {
+  await stateLoader.flush();
+  closeDatabase();
+});
+
+// --- Test helpers ---
+
+function testConfig(): CortexConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    ingestApiKey: "test-key",
+    synapseUrl: mockSynapseUrl,
+    engramUrl: "http://127.0.0.1:1", // Unreachable - tests don't need Engram
+    models: ["test-model"],
+    activeWindowSize: 10,
+    extractionInterval: 3,
+    turnTtlDays: 30,
+    schedulerTickSeconds: 30,
+    schedulerTimezone: "UTC",
+    outboxPollDefaultBatch: 20,
+    outboxLeaseSeconds: 60,
+    outboxMaxAttempts: 10,
+    inboxMaxAttempts: 5,
+    skillDirs: [],
+    skillConfig: {},
+    toolTimeoutMs: 20000,
+    maxToolRounds: 8,
+    synapseTimeoutMs: 60_000,
+    thalamusModels: ["test-model"],
+    thalamusSyncIntervalMs: 21_600_000,
+  };
+}
+
+function openaiResponse(content: string) {
+  return {
+    id: "chat-test",
+    object: "chat.completion",
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+  };
+}
+
+function openaiToolCallResponse(
+  toolCalls: Array<{ name: string; arguments: string }>,
+) {
+  return {
+    id: "chat-test",
+    object: "chat.completion",
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: "assistant",
+          content: "",
+          tool_calls: toolCalls.map((tc, i) => ({
+            id: `call_${i}`,
+            type: "function",
+            function: tc,
+          })),
+        },
+        finish_reason: "tool_calls",
+      },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+  };
+}
+
+function createMockRegistry(opts: {
+  mutatingTools?: string[];
+  executeResult?: SkillToolResult;
+}): SkillRegistry {
+  const mutatingSet = new Set(opts.mutatingTools ?? []);
+  const tools = [
+    {
+      name: "safe.read",
+      description: "Read-only tool",
+      inputSchema: { type: "object", properties: {} },
+      mutatesState: false,
+    },
+    {
+      name: "dangerous.delete",
+      description: "Mutating tool",
+      inputSchema: { type: "object", properties: { id: { type: "string" } } },
+      mutatesState: true,
+    },
+  ];
+
+  return {
+    tools,
+    async executeTool(_name, _argumentsJson, _ctx) {
+      return ok(opts.executeResult ?? { content: "executed" });
+    },
+    isMutating(name) {
+      if (mutatingSet.has(name)) return true;
+      return name === "dangerous.delete";
+    },
+  };
+}
+
+function ingestMessage(
+  overrides: Partial<{
+    channel: string;
+    externalMessageId: string;
+    topicKey: string;
+    userId: string;
+    text: string;
+    metadata: Record<string, unknown>;
+  }> = {},
+) {
+  const id = crypto.randomUUID().slice(0, 8);
+  return enqueueInboxMessage(stateLoader, {
+    channel: overrides.channel ?? "test",
+    externalMessageId: overrides.externalMessageId ?? `msg-${id}`,
+    topicKey: overrides.topicKey ?? "topic-1",
+    userId: overrides.userId ?? "user-1",
+    text: overrides.text ?? "Hello",
+    occurredAt: Date.now(),
+    idempotencyKey: `key-${id}`,
+    metadata: overrides.metadata,
+  });
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 5000,
+  pollMs = 50,
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+    }
+    await Bun.sleep(pollMs);
+  }
+}
+
+function makeFastLoop() {
+  return { pollBusyMs: 10, pollIdleMs: 50, stateLoader };
+}
+
+// --- Tests ---
+
+describe("approval gate - agent loop", () => {
+  test("non-mutating tools execute immediately without approval", async () => {
+    const registry = createMockRegistry({});
+    const openAITools: OpenAITool[] = registry.tools.map((t) => ({
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.inputSchema,
+      },
+    }));
+
+    let callNum = 0;
+    mockSynapseHandler = async () => {
+      callNum++;
+      if (callNum === 1) {
+        return Response.json(
+          openaiToolCallResponse([{ name: "safe.read", arguments: "{}" }]),
+        );
+      }
+      return Response.json(openaiResponse("Read complete"));
+    };
+
+    const result = await runAgentLoop({
+      messages: [{ role: "user", content: "Read something" }],
+      tools: openAITools,
+      registry,
+      config: {
+        models: ["test-model"],
+        synapseUrl: mockSynapseUrl,
+        toolTimeoutMs: 10000,
+        maxToolRounds: 8,
+        skillConfig: {},
+      },
+      stateLoader,
+      topicKey: "topic-1",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok result");
+    expect(result.value.needsApproval).toBeFalsy();
+    expect(result.value.response).toBe("Read complete");
+
+    // No approvals created
+    const pending = listPendingApprovals(stateLoader);
+    expect(pending).toHaveLength(0);
+  });
+
+  test("mutating tools block and create pending approval", async () => {
+    const registry = createMockRegistry({});
+    const openAITools: OpenAITool[] = registry.tools.map((t) => ({
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.inputSchema,
+      },
+    }));
+
+    mockSynapseHandler = async () => {
+      return Response.json(
+        openaiToolCallResponse([
+          { name: "dangerous.delete", arguments: '{"id":"123"}' },
+        ]),
+      );
+    };
+
+    const result = await runAgentLoop({
+      messages: [{ role: "user", content: "Delete item 123" }],
+      tools: openAITools,
+      registry,
+      config: {
+        models: ["test-model"],
+        synapseUrl: mockSynapseUrl,
+        toolTimeoutMs: 10000,
+        maxToolRounds: 8,
+        skillConfig: {},
+      },
+      stateLoader,
+      topicKey: "topic-1",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok result");
+    expect(result.value.needsApproval).toBe(true);
+    expect(result.value.approvalId).toBeTruthy();
+    expect(result.value.blockedToolCalls).toHaveLength(1);
+    expect(result.value.blockedToolCalls?.[0].function.name).toBe(
+      "dangerous.delete",
+    );
+
+    // Approval created
+    const pending = listPendingApprovals(stateLoader, "topic-1");
+    expect(pending).toHaveLength(1);
+    expect(pending[0].toolName).toBe("dangerous.delete");
+    expect(pending[0].agentStateJson).toBeTruthy();
+    expect(pending[0].toolCallsJson).toBeTruthy();
+  });
+
+  test("approved approval is consumed and tools execute", async () => {
+    const registry = createMockRegistry({});
+    const openAITools: OpenAITool[] = registry.tools.map((t) => ({
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.inputSchema,
+      },
+    }));
+
+    // First create an approved approval
+    const approval = proposeApproval(stateLoader, {
+      topicKey: "topic-1",
+      action: "test",
+      toolName: "dangerous.delete",
+      toolArgsJson: '{"id":"123"}',
+    });
+    await resolveApproval(stateLoader, approval.id, "approved");
+
+    let callNum = 0;
+    mockSynapseHandler = async () => {
+      callNum++;
+      if (callNum === 1) {
+        return Response.json(
+          openaiToolCallResponse([
+            { name: "dangerous.delete", arguments: '{"id":"123"}' },
+          ]),
+        );
+      }
+      return Response.json(openaiResponse("Deleted"));
+    };
+
+    const result = await runAgentLoop({
+      messages: [{ role: "user", content: "Delete item 123" }],
+      tools: openAITools,
+      registry,
+      config: {
+        models: ["test-model"],
+        synapseUrl: mockSynapseUrl,
+        toolTimeoutMs: 10000,
+        maxToolRounds: 8,
+        skillConfig: {},
+      },
+      stateLoader,
+      topicKey: "topic-1",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok result");
+    expect(result.value.needsApproval).toBeFalsy();
+    expect(result.value.response).toBe("Deleted");
+
+    // Approval consumed
+    const consumed = stateLoader.get(PendingApproval, approval.id);
+    expect(consumed?.status).toBe("consumed");
+  });
+});
+
+describe("approval gate - expiration", () => {
+  test("isExpired returns true for expired approval", () => {
+    const approval = proposeApproval(stateLoader, {
+      topicKey: "topic-1",
+      action: "test",
+    });
+
+    // Check at future time past expiry
+    const futureTime = approval.proposedAt + APPROVAL_TTL_MS + 1000;
+    expect(isExpired(approval, futureTime)).toBe(true);
+  });
+
+  test("expired approval is not consumed", async () => {
+    const registry = createMockRegistry({});
+    const openAITools: OpenAITool[] = registry.tools.map((t) => ({
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.inputSchema,
+      },
+    }));
+
+    // Create an approved but expired approval
+    const approval = proposeApproval(stateLoader, {
+      topicKey: "topic-1",
+      action: "test",
+      toolName: "dangerous.delete",
+    });
+    // Manually set expiresAt to past
+    approval.expiresAt = Date.now() - 1000;
+    await approval.save();
+    await resolveApproval(stateLoader, approval.id, "approved");
+
+    mockSynapseHandler = async () => {
+      return Response.json(
+        openaiToolCallResponse([
+          { name: "dangerous.delete", arguments: '{"id":"123"}' },
+        ]),
+      );
+    };
+
+    const result = await runAgentLoop({
+      messages: [{ role: "user", content: "Delete" }],
+      tools: openAITools,
+      registry,
+      config: {
+        models: ["test-model"],
+        synapseUrl: mockSynapseUrl,
+        toolTimeoutMs: 10000,
+        maxToolRounds: 8,
+        skillConfig: {},
+      },
+      stateLoader,
+      topicKey: "topic-1",
+    });
+
+    // Should need new approval since the existing one is expired
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok result");
+    expect(result.value.needsApproval).toBe(true);
+  });
+});
+
+describe("approval gate - state serialization", () => {
+  test("agent state is correctly serialized in approval", async () => {
+    const registry = createMockRegistry({});
+    const openAITools: OpenAITool[] = registry.tools.map((t) => ({
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.inputSchema,
+      },
+    }));
+
+    mockSynapseHandler = async () => {
+      return Response.json(
+        openaiToolCallResponse([
+          { name: "dangerous.delete", arguments: '{"id":"456"}' },
+        ]),
+      );
+    };
+
+    const result = await runAgentLoop({
+      messages: [
+        { role: "system", content: "You are helpful" },
+        { role: "user", content: "Delete item 456" },
+      ],
+      tools: openAITools,
+      registry,
+      config: {
+        models: ["test-model"],
+        synapseUrl: mockSynapseUrl,
+        toolTimeoutMs: 10000,
+        maxToolRounds: 8,
+        skillConfig: {},
+      },
+      stateLoader,
+      topicKey: "topic-1",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected ok result");
+    expect(result.value.needsApproval).toBe(true);
+
+    const pending = listPendingApprovals(stateLoader, "topic-1");
+    expect(pending).toHaveLength(1);
+
+    // Verify state is correctly serialized
+    const agentState = JSON.parse(pending[0].agentStateJson!);
+    expect(agentState).toBeArray();
+    // Should include system, user, and assistant (with tool_calls) messages
+    expect(agentState.length).toBeGreaterThanOrEqual(3);
+    expect(agentState[0].role).toBe("system");
+    expect(agentState[1].role).toBe("user");
+    expect(agentState[2].role).toBe("assistant");
+    expect(agentState[2].tool_calls).toBeTruthy();
+
+    // Verify tool calls are serialized
+    const toolCalls = JSON.parse(pending[0].toolCallsJson!);
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0].function.name).toBe("dangerous.delete");
+    expect(toolCalls[0].function.arguments).toBe('{"id":"456"}');
+  });
+});
+
+describe("approval gate - handleApprovalResponse", () => {
+  test("reject action returns cancellation message", async () => {
+    const registry = createMockRegistry({});
+    const openAITools: OpenAITool[] = registry.tools.map((t) => ({
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.inputSchema,
+      },
+    }));
+
+    const approval = proposeApproval(stateLoader, {
+      topicKey: "topic-1",
+      action: "test",
+      toolName: "dangerous.delete",
+      agentStateJson: "[]",
+      toolCallsJson: "[]",
+    });
+
+    const result = await handleApprovalResponse(
+      stateLoader,
+      approval.id,
+      "reject",
+      testConfig(),
+      registry,
+      openAITools,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.response).toBe("Action cancelled.");
+
+    // Approval should be rejected
+    const updated = stateLoader.get(PendingApproval, approval.id);
+    expect(updated?.status).toBe("rejected");
+  });
+
+  test("not found approval returns error message", async () => {
+    const registry = createMockRegistry({});
+    const openAITools: OpenAITool[] = registry.tools.map((t) => ({
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.inputSchema,
+      },
+    }));
+
+    const result = await handleApprovalResponse(
+      stateLoader,
+      "non-existent-id",
+      "approve",
+      testConfig(),
+      registry,
+      openAITools,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.response).toContain("not found");
+  });
+
+  test("already processed approval returns error message", async () => {
+    const registry = createMockRegistry({});
+    const openAITools: OpenAITool[] = registry.tools.map((t) => ({
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.inputSchema,
+      },
+    }));
+
+    const approval = proposeApproval(stateLoader, {
+      topicKey: "topic-1",
+      action: "test",
+    });
+    await resolveApproval(stateLoader, approval.id, "approved");
+
+    const result = await handleApprovalResponse(
+      stateLoader,
+      approval.id,
+      "approve",
+      testConfig(),
+      registry,
+      openAITools,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.response).toContain("already been processed");
+  });
+
+  test("expired approval returns expiry message", async () => {
+    const registry = createMockRegistry({});
+    const openAITools: OpenAITool[] = registry.tools.map((t) => ({
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.inputSchema,
+      },
+    }));
+
+    const approval = proposeApproval(stateLoader, {
+      topicKey: "topic-1",
+      action: "test",
+    });
+    // Manually expire
+    approval.expiresAt = Date.now() - 1000;
+    await approval.save();
+
+    const result = await handleApprovalResponse(
+      stateLoader,
+      approval.id,
+      "approve",
+      testConfig(),
+      registry,
+      openAITools,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.response).toContain("expired");
+
+    // Should be marked as expired
+    const updated = stateLoader.get(PendingApproval, approval.id);
+    expect(updated?.status).toBe("expired");
+  });
+
+  test("approve action resumes agent loop and executes tools", async () => {
+    const registry = createMockRegistry({
+      executeResult: { content: "Tool executed!" },
+    });
+    const openAITools: OpenAITool[] = registry.tools.map((t) => ({
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.inputSchema,
+      },
+    }));
+
+    // Create approval with serialized state
+    const agentState = [
+      { role: "system", content: "You are helpful" },
+      { role: "user", content: "Delete item" },
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call_0",
+            type: "function",
+            function: { name: "dangerous.delete", arguments: '{"id":"999"}' },
+          },
+        ],
+      },
+    ];
+    const toolCalls = [
+      {
+        id: "call_0",
+        type: "function",
+        function: { name: "dangerous.delete", arguments: '{"id":"999"}' },
+      },
+    ];
+
+    const approval = proposeApproval(stateLoader, {
+      topicKey: "topic-1",
+      action: "test",
+      toolName: "dangerous.delete",
+      toolArgsJson: '{"id":"999"}',
+      agentStateJson: JSON.stringify(agentState),
+      toolCallsJson: JSON.stringify(toolCalls),
+    });
+
+    let callNum = 0;
+    mockSynapseHandler = async () => {
+      callNum++;
+      // After tool execution, return final response
+      return Response.json(openaiResponse("Item deleted successfully"));
+    };
+
+    const result = await handleApprovalResponse(
+      stateLoader,
+      approval.id,
+      "approve",
+      testConfig(),
+      registry,
+      openAITools,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.response).toBe("Item deleted successfully");
+
+    // Approval should be approved
+    const updated = stateLoader.get(PendingApproval, approval.id);
+    expect(updated?.status).toBe("approved");
+  });
+});
+
+describe("approval gate - processing loop integration", () => {
+  test("pending approval blocks new messages and re-presents buttons", async () => {
+    // Create a pending approval
+    const approval = proposeApproval(stateLoader, {
+      topicKey: "topic-block",
+      action: "test",
+      toolName: "dangerous.delete",
+    });
+
+    mockSynapseHandler = () =>
+      Response.json(openaiResponse("Should not reach here"));
+
+    const { eventId } = ingestMessage({
+      text: "New message while approval pending",
+      topicKey: "topic-block",
+    });
+
+    const loop = startProcessingLoop(
+      testConfig(),
+      createMockRegistry({}),
+      makeFastLoop(),
+    );
+
+    await waitFor(
+      () => getInboxMessage(stateLoader, eventId)?.status === "done",
+    );
+    await loop.stop();
+
+    // Message should be done
+    const inbox = getInboxMessage(stateLoader, eventId);
+    expect(inbox?.status).toBe("done");
+
+    // Outbox should have a message with approval buttons
+    const outbox = listOutboxMessagesByTopic(stateLoader, "topic-block");
+    expect(outbox).toHaveLength(1);
+    expect(outbox[0].text).toContain("pending approval");
+
+    const payload = JSON.parse(outbox[0].payload_json!);
+    expect(payload.buttons).toHaveLength(2);
+    expect(payload.buttons[0].callback_data).toContain(approval.id);
+  });
+});

--- a/test/approval.test.ts
+++ b/test/approval.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { StateLoader } from "@shetty4l/core/state";
 import {
+  APPROVAL_TTL_MS,
   consumeApproval,
   getApprovalForTool,
+  isExpired,
   listPendingApprovals,
   proposeApproval,
   resolveApproval,
@@ -39,6 +41,10 @@ describe("approval CRUD", () => {
     expect(approval.proposedAt).toBeGreaterThanOrEqual(before);
     expect(approval.proposedAt).toBeLessThanOrEqual(after);
     expect(approval.resolvedAt).toBeNull();
+    expect(approval.agentStateJson).toBeNull();
+    expect(approval.toolCallsJson).toBeNull();
+    expect(approval.expiresAt).toBeGreaterThanOrEqual(before + APPROVAL_TTL_MS);
+    expect(approval.expiresAt).toBeLessThanOrEqual(after + APPROVAL_TTL_MS);
   });
 
   test("proposeApproval with toolName and toolArgsJson", () => {
@@ -51,6 +57,23 @@ describe("approval CRUD", () => {
 
     expect(approval.toolName).toBe("gmail.send");
     expect(approval.toolArgsJson).toBe('{"to":"test@example.com"}');
+  });
+
+  test("proposeApproval with agentStateJson and toolCallsJson", () => {
+    const agentState = JSON.stringify([{ role: "user", content: "test" }]);
+    const toolCalls = JSON.stringify([
+      { id: "tc1", function: { name: "test" } },
+    ]);
+
+    const approval = proposeApproval(stateLoader, {
+      topicKey: "trip",
+      action: "execute_tool",
+      agentStateJson: agentState,
+      toolCallsJson: toolCalls,
+    });
+
+    expect(approval.agentStateJson).toBe(agentState);
+    expect(approval.toolCallsJson).toBe(toolCalls);
   });
 
   test("resolveApproval with approved sets status and resolved_at", async () => {
@@ -164,5 +187,52 @@ describe("approval CRUD", () => {
     console.warn = originalWarn;
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain("not in approved status");
+  });
+});
+
+describe("isExpired", () => {
+  test("returns false when expiresAt is 0", () => {
+    const approval = proposeApproval(stateLoader, {
+      topicKey: "trip",
+      action: "test",
+    });
+    // Manually set expiresAt to 0 to test edge case
+    approval.expiresAt = 0;
+
+    expect(isExpired(approval)).toBe(false);
+  });
+
+  test("returns false when current time is before expiresAt", () => {
+    const approval = proposeApproval(stateLoader, {
+      topicKey: "trip",
+      action: "test",
+    });
+
+    // Check with current time (should not be expired)
+    expect(isExpired(approval)).toBe(false);
+  });
+
+  test("returns true when current time equals expiresAt", () => {
+    const approval = proposeApproval(stateLoader, {
+      topicKey: "trip",
+      action: "test",
+    });
+
+    // Check at exact expiry time
+    expect(isExpired(approval, approval.expiresAt)).toBe(true);
+  });
+
+  test("returns true when current time is after expiresAt", () => {
+    const approval = proposeApproval(stateLoader, {
+      topicKey: "trip",
+      action: "test",
+    });
+
+    // Check after expiry
+    expect(isExpired(approval, approval.expiresAt + 1000)).toBe(true);
+  });
+
+  test("APPROVAL_TTL_MS is 15 minutes", () => {
+    expect(APPROVAL_TTL_MS).toBe(15 * 60 * 1000);
   });
 });


### PR DESCRIPTION
## Summary
- Add approval gate for mutating tools with button-based UX
- Block new messages while approval is pending (re-presents buttons)
- Support approve/reject flows with state serialization/deserialization
- 15 minute TTL for pending approvals

## Commits
- feat(cortex): approval gate for mutating tools

## Validation
All checks pass.

---
Closes #36