### PR TITLE
fix: add busy_timeout to ConnectionPool for concurrent access

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -129,6 +129,7 @@ export function createConnectionPool(dbPath: string): ConnectionPool {
         if (dbPath !== ":memory:") {
           conn.exec("PRAGMA journal_mode = WAL;");
         }
+        conn.exec("PRAGMA busy_timeout = 5000;"); // Wait up to 5s for locks
         conn.exec("PRAGMA foreign_keys = ON");
         connections.set(consumerId, conn);
       }


### PR DESCRIPTION
## Summary
- Add `PRAGMA busy_timeout = 5000` to ConnectionPool connections
- Prevents "database is locked" errors when multiple consumers access DB simultaneously

## Related
- Companion fixes in core (deferred transactions) and wilson (approval metadata) already merged to main