### PR TITLE
fix: execute approved tools immediately instead of re-running LLM

### DIFF
--- a/src/inbox/index.ts
+++ b/src/inbox/index.ts
@@ -40,6 +40,8 @@ export class InboxMessage extends CollectionEntity {
   @Field("number") processing_ms: number | null = null;
   /** Links to approval if this message triggered one; set when approval created */
   @Field("string") approvalId: string | null = null;
+  /** Tool result from approved tool execution (JSON string with tool_call_id, name, arguments, content) */
+  @Field("string") approval_tool_result: string | null = null;
   /** Message type for Cerebellum routing. Default: "conversational" */
   @Field("string") @Index() message_type: MessageType = "conversational";
 

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -44,7 +44,7 @@ import {
 } from "./inbox";
 import { enqueueOutboxMessage } from "./outbox";
 import { buildPrompt, loadAndRenderSystemPrompt } from "./prompt";
-import type { SkillRegistry } from "./skills";
+import type { SkillRegistry, SkillRuntimeContext } from "./skills";
 import {
   ExtractionCursorState,
   type StateLoader as IStateLoader,
@@ -326,24 +326,96 @@ export function startProcessingLoop(
                 return;
               }
 
-              // Approve: resolve approval, re-queue original message for processing
+              // Approve: execute the stored tool call, then re-queue for continuation
               await resolveApproval(stateLoader, approvalId, "approved");
               const originalMessage = getInboxMessage(
                 stateLoader,
                 approval.inboxMessageId,
               );
-              if (originalMessage) {
-                // Re-queue: set status back to pending so it gets picked up
+
+              if (
+                originalMessage &&
+                approval.toolName &&
+                approval.toolArgsJson
+              ) {
+                // Build runtime context for tool execution
+                const toolCtx: SkillRuntimeContext = {
+                  nowIso: new Date().toISOString(),
+                  config:
+                    config.skillConfig?.[approval.toolName.split(".")[0]] ?? {},
+                  db: {
+                    query: () => {
+                      throw new Error("db not available in approval context");
+                    },
+                    run: () => {
+                      throw new Error("db not available in approval context");
+                    },
+                  },
+                  http: { fetch: globalThis.fetch },
+                };
+
+                // Execute the approved tool directly
+                log(
+                  `[${message.topic_key}] executing approved tool: ${approval.toolName}`,
+                );
+                const toolResult = await registry.executeTool(
+                  approval.toolName,
+                  approval.toolArgsJson,
+                  toolCtx,
+                );
+
+                if (!toolResult.ok) {
+                  // Tool failed - retry the original message
+                  log(
+                    `[${message.topic_key}] approved tool failed: ${toolResult.error}, will retry`,
+                  );
+                  originalMessage.status = "pending";
+                  originalMessage.next_attempt_at = Date.now() + 5000; // Retry in 5s
+                  originalMessage.error = `Approved tool failed: ${toolResult.error}`;
+                  await originalMessage.save();
+
+                  enqueueOutboxMessage(stateLoader, {
+                    channel: resolveOutputChannel(message.channel, config),
+                    topicKey: message.topic_key,
+                    text: "Approved, but execution failed. Retrying...",
+                  });
+                } else {
+                  // Tool succeeded - store result and re-queue for LLM continuation
+                  log(
+                    `[${message.topic_key}] approved tool succeeded: ${approval.toolName}`,
+                  );
+
+                  originalMessage.approval_tool_result = JSON.stringify({
+                    tool_call_id: `approved_${approval.id}`,
+                    name: approval.toolName,
+                    arguments: approval.toolArgsJson,
+                    content: toolResult.value.content,
+                  });
+                  originalMessage.status = "pending";
+                  originalMessage.next_attempt_at = 0;
+                  await originalMessage.save();
+
+                  enqueueOutboxMessage(stateLoader, {
+                    channel: resolveOutputChannel(message.channel, config),
+                    topicKey: message.topic_key,
+                    text: "Approved. Processing your request...",
+                  });
+                }
+              } else if (originalMessage) {
+                // No tool stored - just re-queue (fallback, shouldn't happen)
+                log(
+                  `[${message.topic_key}] approval has no stored tool, re-queuing message`,
+                );
                 originalMessage.status = "pending";
                 originalMessage.next_attempt_at = 0;
                 await originalMessage.save();
-              }
 
-              enqueueOutboxMessage(stateLoader, {
-                channel: resolveOutputChannel(message.channel, config),
-                topicKey: message.topic_key,
-                text: "Approved. Processing your request...",
-              });
+                enqueueOutboxMessage(stateLoader, {
+                  channel: resolveOutputChannel(message.channel, config),
+                  topicKey: message.topic_key,
+                  text: "Approved. Processing your request...",
+                });
+              }
 
               const processingMs = Math.round(performance.now() - startMs);
               await completeInboxMessage(stateLoader, message.id, processingMs);
@@ -464,6 +536,49 @@ export function startProcessingLoop(
               userText: message.text,
               messageType: message.message_type,
             });
+
+            // 4b. Inject pre-executed tool result if this is a re-run after approval
+            if (approvalGranted && message.approval_tool_result) {
+              try {
+                const stored = JSON.parse(message.approval_tool_result);
+
+                // Inject assistant message with tool call
+                messages.push({
+                  role: "assistant",
+                  content: "",
+                  tool_calls: [
+                    {
+                      id: stored.tool_call_id,
+                      type: "function",
+                      function: {
+                        name: stored.name,
+                        arguments: stored.arguments,
+                      },
+                    },
+                  ],
+                });
+
+                // Inject tool result
+                messages.push({
+                  role: "tool",
+                  content: stored.content,
+                  tool_call_id: stored.tool_call_id,
+                  name: stored.name,
+                });
+
+                log(
+                  `[${message.topic_key}] injected pre-executed tool result for ${stored.name}`,
+                );
+
+                // Clear after use
+                message.approval_tool_result = null;
+                await message.save();
+              } catch (e) {
+                log(
+                  `[${message.topic_key}] failed to parse approval_tool_result: ${e}`,
+                );
+              }
+            }
 
             // Emit context event (char counts only)
             if (debug.isEnabled()) {

--- a/test/approval-gate.test.ts
+++ b/test/approval-gate.test.ts
@@ -766,4 +766,106 @@ describe("approval gate - processing loop integration", () => {
     const finalResponse = outbox.find((m) => m.text.includes("deleted"));
     expect(finalResponse).toBeTruthy();
   });
+
+  test("approved tool executes directly on approval (not on LLM re-run)", async () => {
+    // This test verifies: the stored tool call executes immediately on approval,
+    // regardless of what the LLM might return on a second call.
+    //
+    // BUG: Currently, approval just re-queues the message and hopes the LLM
+    // makes the same tool call again. This test proves that's unreliable.
+
+    let toolExecuted = false;
+    let executedArgs = "";
+
+    const mockRegistry: SkillRegistry = {
+      tools: [
+        {
+          name: "dangerous.delete",
+          description: "Mutating tool",
+          inputSchema: {
+            type: "object",
+            properties: { id: { type: "string" } },
+          },
+          mutatesState: true,
+        },
+      ],
+      async executeTool(name: string, argsJson: string) {
+        if (name === "dangerous.delete") {
+          toolExecuted = true;
+          executedArgs = argsJson;
+          return ok({ content: `Deleted ${JSON.parse(argsJson).id}` });
+        }
+        return ok({ content: "ok" });
+      },
+      isMutating(name) {
+        return name === "dangerous.delete";
+      },
+    };
+
+    let callNum = 0;
+    mockSynapseHandler = async () => {
+      callNum++;
+      if (callNum === 1) {
+        // First: LLM requests tool call with id=999
+        return Response.json(
+          openaiToolCallResponse([
+            { name: "dangerous.delete", arguments: '{"id":"999"}' },
+          ]),
+        );
+      }
+      if (callNum === 2) {
+        // Second: approval message generation
+        return Response.json(openaiResponse("Delete item 999?"));
+      }
+      // Third+: After approval, LLM returns DIFFERENT response (simulating non-determinism)
+      // It does NOT call the tool again - just returns text
+      return Response.json(openaiResponse("What would you like me to delete?"));
+    };
+
+    const { id: inboxMessageId } = ingestMessage({
+      text: "Delete item 999",
+      topicKey: "topic-direct-exec",
+    });
+
+    const loop = startProcessingLoop(
+      testConfig(),
+      mockRegistry,
+      makeFastLoop(),
+    );
+
+    // Wait for approval to be created
+    await waitFor(
+      () => listPendingApprovals(stateLoader, "topic-direct-exec").length > 0,
+    );
+    const approval = listPendingApprovals(stateLoader, "topic-direct-exec")[0];
+
+    // Verify tool details are stored in approval
+    expect(approval.toolName).toBe("dangerous.delete");
+    expect(approval.toolArgsJson).toBe('{"id":"999"}');
+
+    // Tool should NOT have executed yet
+    expect(toolExecuted).toBe(false);
+
+    // Send approval response
+    ingestMessage({
+      text: "approve",
+      topicKey: "topic-direct-exec",
+      metadata: {
+        type: "approval_response",
+        approvalId: approval.id,
+        action: "approve",
+      },
+    });
+
+    // Wait for original message to complete
+    await waitFor(
+      () => getInboxMessage(stateLoader, inboxMessageId)?.status === "done",
+    );
+    await loop.stop();
+
+    // CRITICAL ASSERTION: Tool was executed with the STORED args from approval
+    // This should FAIL with current implementation (bug) and PASS after fix
+    expect(toolExecuted).toBe(true);
+    expect(executedArgs).toEqual('{"id":"999"}');
+  });
 });


### PR DESCRIPTION
## Summary
- Fix non-deterministic approval behavior where approved tool calls weren't guaranteed to execute
- When user approves, execute the stored tool call immediately using the persisted args
- Inject tool result into conversation for LLM continuation

## Problem
Previously, approval just re-queued the message for full LLM re-processing. Due to LLM non-determinism, the second call might return a different response (e.g., ask a clarifying question instead of calling the tool).

## Solution
1. Store `approval_tool_result` on InboxMessage entity
2. On approval, execute the tool directly with stored `toolName` + `toolArgsJson`
3. Store result and inject into messages array on re-process
4. LLM continues from tool result instead of regenerating

## Testing
- Added unit test: `approved tool executes directly on approval (not on LLM re-run)`
- All 676 tests pass